### PR TITLE
Minecraft conversions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,8 @@ bld/
 
 # Visual Studio 2015/2017 cache/options directory
 .vs/
+# VSCode options directory
+.vscode/
 # Uncomment if you have tasks that create the project's static files in wwwroot
 #wwwroot/
 

--- a/.gitignore
+++ b/.gitignore
@@ -330,3 +330,6 @@ ASALocalRun/
 
 # MFractors (Xamarin productivity tool) working folder 
 .mfractor/
+
+# ignore all generated yaml files
+Minecraftpe/

--- a/src/AzurePipelinesToGitHubActionsConverter.ConsoleApp/AzurePipelinesToGitHubActionsConverter.ConsoleApp.csproj
+++ b/src/AzurePipelinesToGitHubActionsConverter.ConsoleApp/AzurePipelinesToGitHubActionsConverter.ConsoleApp.csproj
@@ -9,4 +9,8 @@
     <ProjectReference Include="..\AzurePipelinesToGitHubActionsConverter.Core\AzurePipelinesToGitHubActionsConverter.Core.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="CommandLineParser" Version="2.8.0" />
+  </ItemGroup>
+
 </Project>

--- a/src/AzurePipelinesToGitHubActionsConverter.ConsoleApp/Commands/Options/ConvertFileOptions.cs
+++ b/src/AzurePipelinesToGitHubActionsConverter.ConsoleApp/Commands/Options/ConvertFileOptions.cs
@@ -8,7 +8,7 @@ namespace AzurePipelinesToGitHubActionsConverter.ConsoleApp.Commands.Options
         [Option('f', "filePath", Required = true, HelpText = "The file path of the source YAML file")]
         public string FilePath { get; set; }
 
-        [Option('o', "outputPath", Required = false, HelpText = "The folder path to output the generate")]
-        public string OutputPath { get; set; }
+        [Option('o', "outputFolder", Required = false, HelpText = "The folder path where the .github/workflows folder should be created")]
+        public string? OutputFolder { get; set; }
     }
 }

--- a/src/AzurePipelinesToGitHubActionsConverter.ConsoleApp/Commands/Options/ConvertFileOptions.cs
+++ b/src/AzurePipelinesToGitHubActionsConverter.ConsoleApp/Commands/Options/ConvertFileOptions.cs
@@ -1,0 +1,14 @@
+using CommandLine;
+
+namespace AzurePipelinesToGitHubActionsConverter.ConsoleApp.Commands.Options
+{
+    [Verb("convert", HelpText = "Add file contents to the index.")]
+    public class ConvertFileOptions
+    {
+        [Option('f', "filePath", Required = true, HelpText = "The file path of the source YAML file")]
+        public string FilePath { get; set; }
+
+        [Option('o', "outputPath", Required = false, HelpText = "The folder path to output the generate")]
+        public string OutputPath { get; set; }
+    }
+}

--- a/src/AzurePipelinesToGitHubActionsConverter.ConsoleApp/Commands/Options/ExtractAndConvertOptions.cs
+++ b/src/AzurePipelinesToGitHubActionsConverter.ConsoleApp/Commands/Options/ExtractAndConvertOptions.cs
@@ -1,0 +1,39 @@
+using System.Collections.Generic;
+using CommandLine;
+
+namespace AzurePipelinesToGitHubActionsConverter.ConsoleApp.Commands.Options
+{
+    [Verb("extractAndConvert", HelpText = "Extract 1 or more pipelines from Azure DevOps and convert to GitHub Actions")]
+    public class ExtractAndConvertOptions
+    {
+        [Option('a', "account", Required = true, HelpText = "The name of the Azure DevOps account")]
+        public string Account { get; set; }
+
+        [Option('p', "project", Required = true, HelpText = "The name of the Azure DevOps project")]
+        public string Project { get; set; }
+
+        [Option('t', "personalAccessToken", Required = true, HelpText = "The Personal Access Token (PAT) to authenticate with Azure DevOps ")]
+        public string PersonalAccessToken { get; set; }
+
+        [Option('i', "pipelineIds", Required = false, HelpText = "A list of specific Pipeline IDs to process")]
+        public IEnumerable<long> PipelineIds { get; set; }
+
+        [Option('y', "yamlFilename", Required = false, HelpText = "The name of a specific Pipeline Yaml file to process")]
+        public string? YamlFilename { get; set; }
+
+        [Option('b', "baseUrl", Required = false, HelpText = "The base url of your Azure DevOps instance (normally dev.azure.com)")]
+        public string? BaseUrl { get; set; }
+
+        [Option('r', "repositoryName", Required = false, HelpText = "Only process pipelines for a given repository name")]
+        public string? RepositoryName { get; set; }
+
+        [Option('o', "outputFolder", Required = false, HelpText = "The folder path where the .github/workflows folder should be created")]
+        public string? OutputFolder { get; set; }
+
+        [Option('x', "pipelineFolderPrefix", Required = false, HelpText = "A base folder in the repo to look for pipelines in (all others will be ignored)")]
+        public string? PipelineFolderPrefix { get; set; }
+
+        [Option('d', "includeIdInFilename", Required = false, Default = false, HelpText = "Whether or not to include the ID of the pipeline in the output file name - useful for processing large projects where multiple repos may reuse the same file name")]
+        public bool? IncludeIdInFilename { get; set; }
+    }
+}

--- a/src/AzurePipelinesToGitHubActionsConverter.ConsoleApp/Commands/Options/ExtractAndConvertOptions.cs
+++ b/src/AzurePipelinesToGitHubActionsConverter.ConsoleApp/Commands/Options/ExtractAndConvertOptions.cs
@@ -30,8 +30,8 @@ namespace AzurePipelinesToGitHubActionsConverter.ConsoleApp.Commands.Options
         [Option('o', "outputFolder", Required = false, HelpText = "The folder path where the .github/workflows folder should be created")]
         public string? OutputFolder { get; set; }
 
-        [Option('x', "pipelineFolderPrefix", Required = false, HelpText = "A base folder in the repo to look for pipelines in (all others will be ignored)")]
-        public string? PipelineFolderPrefix { get; set; }
+        [Option('x', "pipelineFolderName", Required = false, HelpText = "The folder that the Azure Pipeline is stored in (all others will be ignored)")]
+        public string? PipelineFolderName { get; set; }
 
         [Option('d', "includeIdInFilename", Required = false, Default = false, HelpText = "Whether or not to include the ID of the pipeline in the output file name - useful for processing large projects where multiple repos may reuse the same file name")]
         public bool? IncludeIdInFilename { get; set; }

--- a/src/AzurePipelinesToGitHubActionsConverter.ConsoleApp/Commands/Options/ExtractAndConvertOptions.cs
+++ b/src/AzurePipelinesToGitHubActionsConverter.ConsoleApp/Commands/Options/ExtractAndConvertOptions.cs
@@ -19,21 +19,24 @@ namespace AzurePipelinesToGitHubActionsConverter.ConsoleApp.Commands.Options
         public IEnumerable<long> PipelineIds { get; set; }
 
         [Option('y', "yamlFilename", Required = false, HelpText = "The name of a specific Pipeline Yaml file to process")]
-        public string? YamlFilename { get; set; }
+        public string YamlFilename { get; set; }
 
         [Option('b', "baseUrl", Required = false, HelpText = "The base url of your Azure DevOps instance (normally dev.azure.com)")]
-        public string? BaseUrl { get; set; }
+        public string BaseUrl { get; set; }
 
         [Option('r', "repositoryName", Required = false, HelpText = "Only process pipelines for a given repository name")]
-        public string? RepositoryName { get; set; }
+        public string RepositoryName { get; set; }
 
         [Option('o', "outputFolder", Required = false, HelpText = "The folder path where the .github/workflows folder should be created")]
-        public string? OutputFolder { get; set; }
+        public string OutputFolder { get; set; }
 
         [Option('x', "pipelineFolderName", Required = false, HelpText = "The folder that the Azure Pipeline is stored in (all others will be ignored)")]
-        public string? PipelineFolderName { get; set; }
+        public string PipelineFolderName { get; set; }
 
         [Option('d', "includeIdInFilename", Required = false, Default = false, HelpText = "Whether or not to include the ID of the pipeline in the output file name - useful for processing large projects where multiple repos may reuse the same file name")]
         public bool? IncludeIdInFilename { get; set; }
+
+        [Option('f', "addWorkflowTrigger", Required = false, Default = false, HelpText = "Whether or not to add a workflow_dispatch trigger to the resulting GitHub Actions workflow")]
+        public bool? AddWorkflowTrigger { get; set; }
     }
 }

--- a/src/AzurePipelinesToGitHubActionsConverter.ConsoleApp/Program.cs
+++ b/src/AzurePipelinesToGitHubActionsConverter.ConsoleApp/Program.cs
@@ -267,7 +267,7 @@ namespace AzurePipelinesToGitHubActionsConverter.ConsoleApp
             if(_missingConverters.Count > 0)
             {
                 Console.WriteLine("The following converters required by these pipelines are:");
-                _missingConverters.ForEach((missingConverter) => Console.Write(missingConverter));
+                _missingConverters.ForEach((missingConverter) => Console.WriteLine(missingConverter));
             }
 
             return retVal;

--- a/src/AzurePipelinesToGitHubActionsConverter.ConsoleApp/Program.cs
+++ b/src/AzurePipelinesToGitHubActionsConverter.ConsoleApp/Program.cs
@@ -1,72 +1,211 @@
 ﻿using AzurePipelinesToGitHubActionsConverter.Core;
 using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using AzurePipelinesToGitHubActionsConverter.ConsoleApp.Commands.Options;
+using AzurePipelinesToGitHubActionsConverter.ConsoleApp.Services;
+using AzurePipelinesToGitHubActionsConverter.Core.Conversion;
 using YamlDotNet.Serialization;
+using CommandLine;
+using Newtonsoft.Json.Linq;
 
 namespace AzurePipelinesToGitHubActionsConverter.ConsoleApp
 {
     class Program
     {
-        static void Main(string[] args)
+        static int Main(string[] args) {
+            return Parser.Default.ParseArguments<ConvertFileOptions, ExtractAndConvertOptions>(args)
+                .MapResult(
+                    (ConvertFileOptions opts) => ConvertFile(opts),
+                    (ExtractAndConvertOptions opts) => ExtractAndConvert(opts),
+                    errs => 1);
+        }
+
+        private static int ConvertFile(ConvertFileOptions opts)
         {
-            //            string input = @"
-            //trigger:
-            //- master
-            //variables:
-            //  buildConfiguration: Release
-            //  vmImage: ubuntu-latest
-            //jobs:
-            //- job: Build
-            //  displayName: Build job
-            //  pool: 
-            //    vmImage: ubuntu-latest
-            //  variables:
-            //    buildConfiguration: Debug
-            //    myJobVariable: 'data'
-            //    myJobVariable2: 'data2'
-            //  steps: 
-            //  - script: dotnet build WebApplication1/WebApplication1.Service/WebApplication1.Service.csproj --configuration $(buildConfiguration) 
-            //    displayName: dotnet build part 1
-            //- job: Build2
-            //  displayName: Build job
-            //  dependsOn: Build
-            //  pool: 
-            //    vmImage: ubuntu-latest
-            //  variables:
-            //    myJobVariable: 'data'
-            //  steps:
-            //  - script: dotnet build WebApplication1/WebApplication1.Service/WebApplication1.Service.csproj --configuration $(buildConfiguration) 
-            //    displayName: dotnet build part 2
-            //  - script: dotnet build WebApplication1/WebApplication1.Service/WebApplication1.Service.csproj --configuration $(buildConfiguration) 
-            //    displayName: dotnet build part 3";
+            int retVal = 0;
 
-            //            //Process the input
-            //            Conversion conversion = new Conversion();
-            //            ConversionResult gitHubOutput = conversion.ConvertAzurePipelineToGitHubAction(input);
+            // Make sure the source file path actually exists before trying to process
+            if (!File.Exists(opts.FilePath))
+            {
+                Console.WriteLine($"Invalid input file, file '{opts.FilePath}' does not exist");
+                return 2; // Return error and stop processing
+            }
 
-            //            //Output the result
-            //            Console.WriteLine("Azure Pipelines YAML: " + Environment.NewLine + input);
-            //            Console.WriteLine(Environment.NewLine);
-            //            Console.WriteLine("GitHub Actions YAML: " + Environment.NewLine + gitHubOutput.actionsYaml);
+            // Read the YAML file contents
+            string pipelineYaml = File.ReadAllText(opts.FilePath);
 
-            //string expected = @"
-            //- name: Run Selenium smoke tests on website
-            //  run: |                            
-            //    Write-Host ""Test1""
-            //    Write-Host ""Test2""
-            //   shell: powershell
-            //";
-            string expected = @"
-- name: Run Selenium smoke tests on website
-  run: |
-    Write-Host ""Line 1"" 
-    Write-Host ""Line 2"";
-  shell: powershell
-";
+            string outputBasePath = opts.OutputPath;
 
-            Temp tmpObj = ReadYamlFile<Temp>(expected);
-            string result = WriteYAMLFile<Temp>(tmpObj);
-            Console.WriteLine("Result: " + Environment.NewLine + result);
+            FileInfo inputFileInfo = new FileInfo(opts.FilePath);
 
+            // Check if an output path was provided.  If not, default one and notify the user
+            if (string.IsNullOrWhiteSpace(opts.OutputPath))
+            {
+                outputBasePath = Path.Combine(inputFileInfo.DirectoryName, ".github", "workflows");
+
+                Console.WriteLine($"'outputPath' not provided, defaulting to '{outputBasePath}'");
+            }
+            else
+            {
+                outputBasePath = Path.Combine(opts.OutputPath, ".github", "workflows");
+            }
+
+            if (!Directory.Exists(outputBasePath))
+            {
+                Console.WriteLine($"Creating folder '{outputBasePath}, it did not exist");
+                Directory.CreateDirectory(outputBasePath);
+            }
+
+            try
+            {
+                // Run the converter
+                Conversion conversion = new Conversion();
+
+                var result = conversion.ConvertAzurePipelineToGitHubAction(pipelineYaml);
+
+                // Write the output file
+                File.WriteAllText(Path.Combine(outputBasePath, inputFileInfo.Name), result.actionsYaml);
+            }
+            catch (Exception e)
+            {
+                Console.ForegroundColor = ConsoleColor.Red;
+
+                Console.WriteLine($"An error occured converting your pipeline");
+                Console.WriteLine(e.ToString());
+                Console.ResetColor();
+
+                retVal = -1;
+            }
+
+            return retVal;
+        }
+
+        private static int ExtractAndConvert(ExtractAndConvertOptions opts)
+        {
+            int retVal = 0;
+
+            // Check for a provided baseUrl.  If not provided, default
+            string baseUrl = !string.IsNullOrWhiteSpace(opts.BaseUrl)
+                ? opts.BaseUrl
+                : "dev.azure.com";
+
+            AzureDevOpsService adoService = new AzureDevOpsService();
+
+            string continuationToken = string.Empty;
+
+            string outputBasePath = opts.OutputFolder;
+
+            // Check if an output path was provided.  If not, default one and notify the user
+            if (string.IsNullOrWhiteSpace(opts.OutputFolder))
+            {
+                outputBasePath = Path.Combine(Directory.GetCurrentDirectory(), ".github", "workflows");
+
+                Console.WriteLine($"'outputPath' not provided, defaulting to '{outputBasePath}'");
+            }
+            else
+            {
+                outputBasePath = Path.Combine(opts.OutputFolder, ".github", "workflows");
+            }
+
+            if (!Directory.Exists(outputBasePath))
+            {
+                Console.WriteLine($"Creating folder '{outputBasePath}, it did not exist");
+                Directory.CreateDirectory(outputBasePath);
+            }
+
+
+            // Execute a loop
+            do
+            {
+                // Extract each of the pipelines from the ADO project
+                var task = adoService.GetBuildDefinitions(baseUrl, opts.Account, opts.Project,
+                    opts.PersonalAccessToken, opts.PipelineIds.ToList(), opts.YamlFilename, 0, continuationToken);
+
+                Task.WaitAll(task);
+
+                var response = task.Result;
+
+                var pipelines = response["value"] as JArray;
+
+                var yamlPipelines = pipelines.Where((p) => ((JObject)p["process"]).ContainsKey("yamlFilename")).ToList();
+
+                if (!string.IsNullOrEmpty(opts.RepositoryName))
+                {
+                    // Filter the list of pipelines by the repository name
+                    yamlPipelines = yamlPipelines.Where((p) =>
+                            p["repository"]["name"].Value<string>().ToLower() ==
+                            $"{opts.Project.ToLower()}/{opts.RepositoryName.ToLower()}")
+                        .ToList();
+                }
+
+                if(!string.IsNullOrEmpty(opts.PipelineFolderPrefix))
+                {
+                    // Filter the list of pipelines by the repository name
+                    yamlPipelines = yamlPipelines.Where((p) =>
+                            p["path"].Value<string>().ToLower() ==
+                            $"{opts.PipelineFolderPrefix.ToLower()}")
+                        .ToList();
+                }
+
+                foreach (var yamlPipeline in yamlPipelines)
+                {
+                    var pipelineId = yamlPipeline["id"].Value<long>();
+
+                    var task1 = adoService.GetPipelineYaml(baseUrl, opts.Account, opts.Project,
+                        opts.PersonalAccessToken, pipelineId, "6.1-preview.1");
+
+                    Task.WaitAll(task1);
+
+                    var pipelineYaml = task1.Result;
+
+                    if(!string.IsNullOrWhiteSpace(pipelineYaml))
+                    {
+                        var yamlFullFilename = yamlPipeline["process"]["yamlFilename"].Value<string>();
+                        var yamlFilename = yamlFullFilename.Split('/').Last();
+
+                        if (opts.IncludeIdInFilename.Value)
+                            yamlFilename = $"{pipelineId.ToString()}_{yamlFilename}";
+
+                        try
+                        {
+                            // Run the converter
+                            Conversion conversion = new Conversion();
+
+                            var result = conversion.ConvertAzurePipelineToGitHubAction(pipelineYaml);
+
+                            // ToDo: output comments here
+
+                            Console.WriteLine($"Successfully converted {yamlFullFilename}");
+
+                            // Write the output file
+                            File.WriteAllText(Path.Combine(outputBasePath, yamlFilename), result.actionsYaml);
+                        }
+                        catch (Exception e)
+                        {
+                            Console.ForegroundColor = ConsoleColor.Red;
+
+                            Console.WriteLine($"An error occured converting your pipeline");
+                            Console.WriteLine(e.ToString());
+                            Console.ResetColor();
+
+                            retVal = -1;
+                        }
+                    }
+                }
+
+                // After processing each build, check in the response to see if there's a continuationToken, if there is, call
+                // the REST API again, passing the token to get the next set of responses.  Repeat in a do/while loop until
+                // the continuationToken is no longer populated in the header
+                continuationToken = response.ContainsKey("continuationToken") ? response["continuationToken"].ToString() : string.Empty;
+            } while (!string.IsNullOrWhiteSpace(continuationToken));
+
+            // For
+
+            return retVal;
         }
 
         //Read in a YAML file and convert it to a T object
@@ -89,12 +228,5 @@ namespace AzurePipelinesToGitHubActionsConverter.ConsoleApp
 
             return yaml;
         }
-    }
-
-    public class Temp
-    {
-        public string name { get; set; }
-        public string run { get; set; }
-        public string shell { get; set; }
     }
 }

--- a/src/AzurePipelinesToGitHubActionsConverter.ConsoleApp/Program.cs
+++ b/src/AzurePipelinesToGitHubActionsConverter.ConsoleApp/Program.cs
@@ -212,7 +212,7 @@ namespace AzurePipelinesToGitHubActionsConverter.ConsoleApp
                         try
                         {
                             // Run the converter
-                            Conversion conversion = new Conversion();
+                            Conversion conversion = new Conversion(addWorkflowTrigger: opts.AddWorkflowTrigger);
 
                             var result = conversion.ConvertAzurePipelineToGitHubAction(pipelineYaml);
 

--- a/src/AzurePipelinesToGitHubActionsConverter.ConsoleApp/Services/AzureDevOpsService.cs
+++ b/src/AzurePipelinesToGitHubActionsConverter.ConsoleApp/Services/AzureDevOpsService.cs
@@ -1,0 +1,564 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace AzurePipelinesToGitHubActionsConverter.ConsoleApp.Services
+{
+    public class AzureDevOpsService
+    {
+        // Hard code the ADO API version to ensure that we don't inadvertently introduce bugs from upstream
+        // API changes in new release of ADO
+        private readonly string _apiVersion = "5.1";
+
+        private readonly HttpClient _httpClient;
+
+        public AzureDevOpsService()
+        {
+            _httpClient = new HttpClient();
+        }
+
+        public async Task<JObject> GetBuildDefinition(string baseAddress, string organizationName, string projectName,
+            string personalAccessToken, long? definitionId, string? continuationToken = null, string apiVersion = "")
+        {
+            // Query the details of a give build definition
+            UriBuilder uriBuilder = new UriBuilder();
+            uriBuilder.Scheme = "https";
+            uriBuilder.Host = baseAddress;
+            uriBuilder.Path = $"{organizationName}/{projectName}/_apis/build/definitions/{definitionId}";
+
+            // Check to see if the caller has provided an API Version, if not, use the global default version
+            apiVersion = string.IsNullOrWhiteSpace(apiVersion) ? _apiVersion : apiVersion;
+
+            List<string> queryParams = new List<string>()
+            {
+                $"api-version={apiVersion}"
+            };
+
+            // Append a continuationToken if provided
+            if (!string.IsNullOrWhiteSpace(continuationToken))
+                queryParams.Add($"continuationToken={continuationToken}");
+
+            uriBuilder.Query = string.Join("&", queryParams);
+
+            var result = await SendAsync(HttpMethod.Get, uriBuilder.Uri, string.Empty, encodeAuthToken(personalAccessToken), true);
+
+            var json = await result.Content.ReadAsStringAsync();
+
+            var responseObject = JObject.Parse(json);
+
+            // Look for the continuation token in the header and if not empty, add to the returning JObject
+            if (result.Headers.Contains("x-ms-continuationtoken"))
+            {
+                continuationToken = result.Headers.GetValues("x-ms-continuationtoken").FirstOrDefault();
+                if (!string.IsNullOrWhiteSpace(continuationToken))
+                    responseObject.Add("continuationToken", continuationToken);
+            }
+
+            return responseObject;
+        }
+
+        public async Task<JObject> GetBuildDefinitions(string baseAddress, string organizationName, string projectName,
+            string personalAccessToken, List<long>? definitionIds = default(List<long>), string? yamlFilename = "", int top = 0,
+            string? continuationToken = null, string apiVersion = "")
+        {
+            // Query for a list of Builds > a given date
+            UriBuilder uriBuilder = new UriBuilder();
+            uriBuilder.Scheme = "https";
+            uriBuilder.Host = baseAddress;
+            uriBuilder.Path = $"{organizationName}/{projectName}/_apis/build/definitions";
+
+            // Check to see if the caller has provided an API Version, if not, use the global default version
+            apiVersion = string.IsNullOrWhiteSpace(apiVersion) ? _apiVersion : apiVersion;
+
+            List<string> queryParams = new List<string>()
+            {
+                $"api-version={apiVersion}"
+            };
+
+            // If value is specified, set the Yaml file anme to search for builds
+            if (!string.IsNullOrWhiteSpace(yamlFilename))
+                queryParams.Add($"yamlFilename={yamlFilename}");
+
+            // If value is specified, limit the number of items to return
+            if (top > 0)
+                queryParams.Add($"$top={top}");
+
+            if (definitionIds != null && definitionIds.Count > 0)
+                queryParams.Add($"definitionIds={string.Join(",", definitionIds)}");
+
+            // Append a continuationToken if provided
+            if (!string.IsNullOrWhiteSpace(continuationToken))
+                queryParams.Add($"continuationToken={continuationToken}");
+
+            // Make sure to include all the properties
+            queryParams.Add($"includeAllProperties=true");
+
+            uriBuilder.Query = string.Join("&", queryParams);
+
+            var result = await SendAsync(HttpMethod.Get, uriBuilder.Uri, string.Empty, encodeAuthToken(personalAccessToken), true);
+
+            var json = await result.Content.ReadAsStringAsync();
+
+            var responseObject = JObject.Parse(json);
+
+            // Look for the continuation token in the header and if not empty, add to the returning JObject
+            // Need to make sure this is the right place to look for the token - it's in different places in different
+            // calls, and it's not clearly documented here - https://docs.microsoft.com/en-us/rest/api/azure/devops/build/definitions/list?view=azure-devops-rest-6.1
+            if (result.Headers.Contains("x-ms-continuationtoken"))
+            {
+                continuationToken = result.Headers.GetValues("x-ms-continuationtoken").FirstOrDefault();
+                if (!string.IsNullOrWhiteSpace(continuationToken))
+                    responseObject.Add("continuationToken", continuationToken);
+            }
+
+            return responseObject;
+        }
+
+        public async Task<string> GetPipelineYaml(string baseAddress, string organizationName, string projectName,
+            string personalAccessToken, long pipelineId, string apiVersion = "")
+        {
+            // Query for a list of Builds > a given date
+            UriBuilder uriBuilder = new UriBuilder();
+            uriBuilder.Scheme = "https";
+            uriBuilder.Host = baseAddress;
+            uriBuilder.Path = $"{organizationName}/{projectName}/_apis/pipelines/{pipelineId}/runs";
+            // https://dev.azure.com/dev-mc/Minecraft/_apis/pipelines/2225/runs?api-version=6.1-preview.1
+
+            // Check to see if the caller has provided an API Version, if not, use the global default version
+            apiVersion = string.IsNullOrWhiteSpace(apiVersion) ? _apiVersion : apiVersion;
+
+            List<string> queryParams = new List<string>()
+            {
+                $"api-version={apiVersion}"
+            };
+
+            uriBuilder.Query = string.Join("&", queryParams);
+
+            var requestBody = "{\"previewRun\": true}";
+
+            var result = await SendAsync(HttpMethod.Post, uriBuilder.Uri, requestBody, encodeAuthToken(personalAccessToken), false);
+
+            var json = await result.Content.ReadAsStringAsync();
+
+            var responseObject = JObject.Parse(json);
+
+            if (result.StatusCode == HttpStatusCode.BadRequest)
+            {
+                Console.ForegroundColor = ConsoleColor.Red;
+                Console.WriteLine($"Error requesting YAML for Pipeline Id '{pipelineId}'");
+                if(responseObject.ContainsKey("message"))
+                    Console.WriteLine($"Message: {responseObject["message"].Value<string>()}");
+                Console.ResetColor();
+            }
+
+            var finalYaml = responseObject.ContainsKey("finalYaml")
+                ? responseObject["finalYaml"].Value<string>()
+                : string.Empty;
+
+            return finalYaml;
+        }
+
+        public async Task<JObject> GetBuilds(string baseAddress, string organizationName, string projectName,
+            string personalAccessToken, List<long>? definitionIds = default(List<long>), string? minTime = null,
+            string? maxTime = null, int top = 0, string? continuationToken = null, string apiVersion = "")
+        {
+            // Query for a list of Builds > a given date
+            UriBuilder uriBuilder = new UriBuilder();
+            uriBuilder.Scheme = "https";
+            uriBuilder.Host = baseAddress;
+            uriBuilder.Path = $"{organizationName}/{projectName}/_apis/build/builds";
+
+            // Check to see if the caller has provided an API Version, if not, use the global default version
+            apiVersion = string.IsNullOrWhiteSpace(apiVersion) ? _apiVersion : apiVersion;
+
+            List<string> queryParams = new List<string>()
+            {
+                $"api-version={apiVersion}"
+            };
+
+            // If value is specified, set the min date/time to search for builds
+            if (!string.IsNullOrWhiteSpace(minTime))
+                queryParams.Add($"minTime={minTime}");
+
+            // If value is specified, set the min date/time to search for builds
+            if (!string.IsNullOrWhiteSpace(maxTime))
+                queryParams.Add($"maxTime={maxTime}");
+
+            // If value is specified, limit the number of items to return
+            if (top > 0)
+                queryParams.Add($"$top={top}");
+
+            if (definitionIds != null && definitionIds.Count > 0)
+                queryParams.Add($"definitions={string.Join(",", definitionIds)}");
+
+            // Append a continuationToken if provided
+            if (!string.IsNullOrWhiteSpace(continuationToken))
+                queryParams.Add($"continuationToken={continuationToken}");
+
+            uriBuilder.Query = string.Join("&", queryParams);
+
+            var result = await SendAsync(HttpMethod.Get, uriBuilder.Uri, string.Empty, encodeAuthToken(personalAccessToken), true);
+
+            var json = await result.Content.ReadAsStringAsync();
+
+            var responseObject = JObject.Parse(json);
+
+            // Look for the continuation token in the header and if not empty, add to the returning JObject
+            if (result.Headers.Contains("x-ms-continuationtoken"))
+            {
+                continuationToken = result.Headers.GetValues("x-ms-continuationtoken").FirstOrDefault();
+                if (!string.IsNullOrWhiteSpace(continuationToken))
+                    responseObject.Add("continuationToken", continuationToken);
+            }
+
+            return responseObject;
+        }
+
+        public async Task<JObject> GetBuildTimelineRecords(string baseAddress, string organizationName, string projectName, string buildId, string personalAccessToken, string apiVersion = "")
+        {
+            // Query for a list of Builds > a given date
+            UriBuilder uriBuilder = new UriBuilder();
+            uriBuilder.Scheme = "https";
+            uriBuilder.Host = baseAddress;
+            uriBuilder.Path = $"{organizationName}/{projectName}/_apis/build/builds/{buildId}/timeline";
+
+            // Check to see if the caller has provided an API Version, if not, use the global default version
+            apiVersion = string.IsNullOrWhiteSpace(apiVersion) ? _apiVersion : apiVersion;
+
+            List<string> queryParams = new List<string>()
+            {
+                $"api-version={apiVersion}"
+            };
+
+            uriBuilder.Query = string.Join("&", queryParams);
+
+            var result = await SendAsync(HttpMethod.Get, uriBuilder.Uri, string.Empty, encodeAuthToken(personalAccessToken), true);
+
+            var json = await result.Content.ReadAsStringAsync();
+
+            // Check to see if the response has a body - for some builds, this will be empty
+            var responseObject = string.IsNullOrWhiteSpace(json) ? new JObject() : JObject.Parse(json);
+
+            return responseObject;
+        }
+
+        public async Task<JObject> GetWorkItems(string baseAddress, string organizationName, string projectName, string teamName, string wiqlQuery, string personalAccessToken, int top = 0, string apiVersion = "")
+        {
+            UriBuilder uriBuilder = new UriBuilder();
+            uriBuilder.Scheme = "https";
+            uriBuilder.Host = baseAddress;
+
+            if(!string.IsNullOrEmpty(teamName))
+            {
+                uriBuilder.Path = $"{organizationName}/{projectName}/{teamName}/_apis/wit/wiql";
+            }
+            else
+            {
+                uriBuilder.Path = $"{organizationName}/{projectName}/_apis/wit/wiql";
+            }
+
+            // Check to see if the caller has provided an API Version, if not, use the global default version
+            apiVersion = string.IsNullOrWhiteSpace(apiVersion) ? _apiVersion : apiVersion;
+
+            List<string> queryParams = new List<string>()
+            {
+                "timePrecision=true",
+                $"api-version={apiVersion}"
+            };
+
+            // If value is specified, limit the number of items to return
+            if (top > 0)
+                queryParams.Add($"$top={top}");
+
+            uriBuilder.Query = string.Join("&", queryParams);
+
+            // ToDo - Fix this body syntax
+            var requestBody = JsonConvert.SerializeObject(wiqlQuery);
+
+            var result = await SendAsync(HttpMethod.Post, uriBuilder.Uri, requestBody, encodeAuthToken(personalAccessToken), false);
+
+            var json = await result.Content.ReadAsStringAsync();
+
+            JObject queryResult = new JObject();
+
+            // This happens when the request has more results than WIQL queries allow
+            if (result.StatusCode == HttpStatusCode.BadRequest)
+            {
+                JObject badRequestResult = JObject.Parse(json);
+
+                var ex = new Exception(badRequestResult["message"].ToString());
+
+                var exParams = new Dictionary<string, string>()
+                {
+                    {"innerException", badRequestResult["innerException"].ToString()},
+                    {"typeName", badRequestResult["typeName"].ToString()},
+                    {"typeKey", badRequestResult["typeKey"].ToString()},
+                    {"errorCode", badRequestResult["errorCode"].ToString()},
+                    {"eventId", badRequestResult["eventId"].ToString()}
+                };
+            }
+            else
+            {
+                queryResult = JObject.Parse(json);
+            }
+
+            return queryResult;
+        }
+
+        public async Task<string> GetWorkItem(string baseAddress, string organizationName, string projectName, long workItemId, string personalAccessToken, string apiVersion = "")
+        {
+            UriBuilder uriBuilder = new UriBuilder();
+            uriBuilder.Scheme = "https";
+            uriBuilder.Host = baseAddress;
+            uriBuilder.Path = $"{organizationName}/{projectName}/_apis/wit/workItems/{workItemId}";
+
+            // Check to see if the caller has provided an API Version, if not, use the global default version
+            apiVersion = string.IsNullOrWhiteSpace(apiVersion) ? _apiVersion : apiVersion;
+
+            List<string> queryParams = new List<string>()
+            {
+                "$expand=All",
+                $"api-version={apiVersion}"
+            };
+
+            uriBuilder.Query = string.Join("&", queryParams);
+
+            var result = await SendAsync(HttpMethod.Get, uriBuilder.Uri, string.Empty, encodeAuthToken(personalAccessToken), true);
+
+            var json = await result.Content.ReadAsStringAsync();
+
+            return json;
+        }
+
+        public async Task<JObject> GetWorkItemLinks(string baseAddress, string organizationName,
+            string projectName, string personalAccessToken, string? startDateTime = null, string? continuationToken = null, string apiVersion = "")
+        {
+            // Query for a list of WorkItemLinks > a given date
+            UriBuilder uriBuilder = new UriBuilder();
+            uriBuilder.Scheme = "https";
+            uriBuilder.Host = baseAddress;
+            uriBuilder.Path = $"{organizationName}/{projectName}/_apis/wit/reporting/workitemlinks";
+
+            // Check to see if the caller has provided an API Version, if not, use the global default version
+            apiVersion = string.IsNullOrWhiteSpace(apiVersion) ? _apiVersion : apiVersion;
+
+            List<string> queryParams = new List<string>()
+            {
+                $"api-version={apiVersion}"
+            };
+
+            // If value is specified, limit the number of items to return
+            if (!string.IsNullOrEmpty(startDateTime))
+                queryParams.Add($"startDateTime={startDateTime}");
+
+            // Append a continuationToken if provided
+            if(!string.IsNullOrEmpty(continuationToken))
+                queryParams.Add($"continuationToken={continuationToken}");
+
+
+            uriBuilder.Query = string.Join("&", queryParams);
+
+            var result = await SendAsync(HttpMethod.Get, uriBuilder.Uri, string.Empty, encodeAuthToken(personalAccessToken), true);
+
+            var json = await result.Content.ReadAsStringAsync();
+
+            var responseObject = JObject.Parse(json);
+
+            return responseObject;
+        }
+
+        public async Task<JObject> GetProjects(string baseAddress, string organizationName, string personalAccessToken, string? continuationToken = null, string apiVersion = "")
+        {
+            UriBuilder uriBuilder = new UriBuilder();
+            uriBuilder.Scheme = "https";
+            uriBuilder.Host = baseAddress;
+            uriBuilder.Path = $"{organizationName}/_apis/projects";
+
+            // Check to see if the caller has provided an API Version, if not, use the global default version
+            apiVersion = string.IsNullOrWhiteSpace(apiVersion) ? _apiVersion : apiVersion;
+
+            List<string> queryParams = new List<string>()
+            {
+                $"api-version={apiVersion}"
+            };
+
+            // Append a continuationToken if provided
+            if (!string.IsNullOrWhiteSpace(continuationToken))
+                queryParams.Add($"continuationToken={continuationToken}");
+
+            uriBuilder.Query = string.Join("&", queryParams);
+
+            var result = await SendAsync(HttpMethod.Get, uriBuilder.Uri, string.Empty, encodeAuthToken(personalAccessToken), true);
+
+            HttpHeaders headers = result.Headers;
+            IEnumerable<string> values;
+            string token = string.Empty;
+            if (headers.TryGetValues("x-ms-continuationtoken", out values))
+            {
+                token = values.First();
+            }
+
+            var json = await result.Content.ReadAsStringAsync();
+
+            var responseObject = JObject.Parse(json);
+
+            responseObject.Add("continuationToken", token);
+
+            return responseObject;
+        }
+
+        public async Task<JObject> GetTestPlans(string baseAddress, string organizationName, string projectName, string personalAccessToken, string apiVersion = "")
+        {
+            UriBuilder uriBuilder = new UriBuilder();
+            uriBuilder.Scheme = "https";
+            uriBuilder.Host = baseAddress;
+            uriBuilder.Path = $"{organizationName}/{projectName}/_apis/test/plans";
+
+            // Check to see if the caller has provided an API Version, if not, use the global default version
+            apiVersion = string.IsNullOrWhiteSpace(apiVersion) ? _apiVersion : apiVersion;
+
+            List<string> queryParams = new List<string>()
+            {
+                $"filterActivePlans=true",
+                $"api-version={apiVersion}"
+            };
+
+            uriBuilder.Query = string.Join("&", queryParams);
+
+            var result = await SendAsync(HttpMethod.Get, uriBuilder.Uri, string.Empty, encodeAuthToken(personalAccessToken), true);
+
+            var json = await result.Content.ReadAsStringAsync();
+
+            var responseObject = JObject.Parse(json);
+
+            return responseObject;
+        }
+
+        public async Task<JObject> GetTestSuites(string baseAddress, string organizationName, string projectName, string personalAccessToken,
+            long planId, string? continuationToken = null, string apiVersion = "")
+        {
+            UriBuilder uriBuilder = new UriBuilder();
+            uriBuilder.Scheme = "https";
+            uriBuilder.Host = baseAddress;
+            uriBuilder.Path = $"{organizationName}/{projectName}/_apis/testplan/Plans/{planId}/suites";
+
+            // Check to see if the caller has provided an API Version, if not, use the global default version
+            apiVersion = string.IsNullOrWhiteSpace(apiVersion) ? _apiVersion : apiVersion;
+
+            List<string> queryParams = new List<string>()
+            {
+                $"api-version={apiVersion}"
+            };
+
+            // Append a continuationToken if provided
+            if (!string.IsNullOrWhiteSpace(continuationToken))
+                queryParams.Add($"continuationToken={continuationToken}");
+
+            uriBuilder.Query = string.Join("&", queryParams);
+
+            var result = await SendAsync(HttpMethod.Get, uriBuilder.Uri, string.Empty, encodeAuthToken(personalAccessToken), true);
+
+            HttpHeaders headers = result.Headers;
+            IEnumerable<string> values;
+            string token = string.Empty;
+            if (headers.TryGetValues("x-ms-continuationtoken", out values))
+            {
+                token = values.First();
+            }
+
+            var json = await result.Content.ReadAsStringAsync();
+
+            var responseObject = JObject.Parse(json);
+
+            responseObject.Add("continuationToken", token);
+
+            return responseObject;
+        }
+
+        public async Task<JObject> GetTestPoints(string baseAddress, string organizationName, string projectName, string personalAccessToken,
+            long planId, long suiteId, string? continuationToken = null, string apiVersion = "")
+        {
+            UriBuilder uriBuilder = new UriBuilder();
+            uriBuilder.Scheme = "https";
+            uriBuilder.Host = baseAddress;
+            uriBuilder.Path = $"{organizationName}/{projectName}/_apis/test/Plans/{planId}/Suites/{suiteId}/points";
+
+            // Check to see if the caller has provided an API Version, if not, use the global default version
+            apiVersion = string.IsNullOrWhiteSpace(apiVersion) ? _apiVersion : apiVersion;
+
+            List<string> queryParams = new List<string>()
+            {
+                $"includePointDetails=true",
+                $"api-version={apiVersion}"
+            };
+
+            // Append a continuationToken if provided
+            if (!string.IsNullOrWhiteSpace(continuationToken))
+                queryParams.Add($"continuationToken={continuationToken}");
+
+            uriBuilder.Query = string.Join("&", queryParams);
+
+            var result = await SendAsync(HttpMethod.Get, uriBuilder.Uri, string.Empty, encodeAuthToken(personalAccessToken), true);
+
+            HttpHeaders headers = result.Headers;
+            IEnumerable<string> values;
+            string token = string.Empty;
+            if (headers.TryGetValues("x-ms-continuationtoken", out values))
+            {
+                token = values.First();
+            }
+
+            var json = await result.Content.ReadAsStringAsync();
+
+            var responseObject = JObject.Parse(json);
+
+            responseObject.Add("continuationToken", token);
+
+            return responseObject;
+        }
+
+        private AuthenticationHeaderValue encodeAuthToken(string personalAccessToken)
+        {
+            var token64 = Convert.ToBase64String(Encoding.ASCII.GetBytes(":" + personalAccessToken));
+            var auth = new AuthenticationHeaderValue("Basic", token64);
+            return auth;
+        }
+
+        protected async Task<HttpResponseMessage> SendAsync(
+            HttpMethod requestType,
+            Uri requestUri,
+            string json,
+            AuthenticationHeaderValue authToken,
+            bool throwOnException,
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var request = new HttpRequestMessage(requestType, requestUri);
+
+            if (json != null)
+                request.Content = new StringContent(json, Encoding.UTF8, "application/json");
+
+            request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+            request.Headers.Authorization = authToken;
+
+            var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+
+            if (throwOnException)
+                response.EnsureSuccessStatusCode();
+
+            if (response.StatusCode == HttpStatusCode.Unauthorized)
+            {
+                response.EnsureSuccessStatusCode();
+            }
+
+            return response;
+        }
+    }
+}

--- a/src/AzurePipelinesToGitHubActionsConverter.Core/Conversion.cs
+++ b/src/AzurePipelinesToGitHubActionsConverter.Core/Conversion.cs
@@ -217,6 +217,7 @@ namespace AzurePipelinesToGitHubActionsConverter.Core.Conversion
 
             //convert the yaml into json, it's easier to parse
             JObject json = null;
+
             if (yaml != null)
             {
                 //Clean up the YAML to remove conditional insert statements
@@ -246,6 +247,7 @@ namespace AzurePipelinesToGitHubActionsConverter.Core.Conversion
                     triggerYaml = ConversionUtility.ProcessNoneJsonElement(triggerYaml);
                     gitHubActions.on = tp.ProcessTriggerV2(triggerYaml);
                 }
+
                 if (json["pr"] != null)
                 {
                     string prYaml = json["pr"].ToString();
@@ -260,6 +262,7 @@ namespace AzurePipelinesToGitHubActionsConverter.Core.Conversion
                         gitHubActions.on.pull_request = prTrigger.pull_request;
                     }
                 }
+
                 if (json["schedules"] != null)
                 {
                     string schedulesYaml = json["schedules"].ToString();
@@ -288,24 +291,27 @@ namespace AzurePipelinesToGitHubActionsConverter.Core.Conversion
 
                 //Resources
                 string resourcesYaml = json["resources"]?.ToString();
+
                 //Resource Pipelines
                 if (resourcesYaml?.IndexOf("\"pipelines\"") >= 0)
                 {
                     gitHubActions.messages.Add("TODO: Resource pipelines conversion not yet done: https://github.com/samsmithnz/AzurePipelinesToGitHubActionsConverter/issues/8");
                 }
+
                 //Resource Repositories
                 if (resourcesYaml?.IndexOf("\"repositories\"") >= 0)
                 {
                     gitHubActions.messages.Add("TODO: Resource repositories conversion not yet done: https://github.com/samsmithnz/AzurePipelinesToGitHubActionsConverter/issues/8");
                 }
+
                 //Resource Container
                 if (resourcesYaml?.IndexOf("\"containers\"") >= 0)
                 {
                     gitHubActions.messages.Add("TODO: Container conversion not yet done, we need help!: https://github.com/samsmithnz/AzurePipelinesToGitHubActionsConverter/issues/39");
                 }
+
                 //Strategy
                 string strategyYaml = json["strategy"]?.ToString();
-
 
                 //If we have stages, convert them into jobs first:
                 if (json["stages"] != null)
@@ -313,6 +319,7 @@ namespace AzurePipelinesToGitHubActionsConverter.Core.Conversion
                     StagesProcessing sp = new StagesProcessing(_verbose);
                     gitHubActions.jobs = sp.ProcessStagesV2(json["stages"], strategyYaml);
                 }
+
                 //If we don't have stages, but have jobs:
                 else if (json["stages"] == null && json["jobs"] != null)
                 {
@@ -368,6 +375,7 @@ namespace AzurePipelinesToGitHubActionsConverter.Core.Conversion
                         stepComments.Add(ConversionUtility.ConvertMessageToYamlComment(message));
                     }
                 }
+
                 if (gitHubActions?.jobs != null)
                 {
                     //Add each individual step comments
@@ -379,6 +387,7 @@ namespace AzurePipelinesToGitHubActionsConverter.Core.Conversion
                             {
                                 stepComments.Add(ConversionUtility.ConvertMessageToYamlComment(job.Value.job_message));
                             }
+
                             foreach (GitHubActions.Step step in job.Value.steps)
                             {
                                 if (step != null && string.IsNullOrEmpty(step.step_message) == false)
@@ -389,7 +398,6 @@ namespace AzurePipelinesToGitHubActionsConverter.Core.Conversion
                         }
                     }
                 }
-
             }
 
             //Append all of the comments to the top of the file

--- a/src/AzurePipelinesToGitHubActionsConverter.Core/Conversion.cs
+++ b/src/AzurePipelinesToGitHubActionsConverter.Core/Conversion.cs
@@ -12,10 +12,12 @@ namespace AzurePipelinesToGitHubActionsConverter.Core.Conversion
     {
         private string _matrixVariableName;
         private readonly bool _verbose;
+        private readonly bool _addWorkflowTrigger;
 
-        public Conversion(bool verbose = true)
+        public Conversion(bool verbose = true, bool? addWorkflowTrigger = null)
         {
             _verbose = verbose;
+            _addWorkflowTrigger = addWorkflowTrigger ?? false;
         }
 
         /// <summary>
@@ -237,6 +239,7 @@ namespace AzurePipelinesToGitHubActionsConverter.Core.Conversion
 
                 //Trigger/PR/Schedules
                 TriggerProcessing tp = new TriggerProcessing(_verbose);
+
                 if (json["trigger"] != null)
                 {
                     string triggerYaml = json["trigger"].ToString();
@@ -269,6 +272,12 @@ namespace AzurePipelinesToGitHubActionsConverter.Core.Conversion
                     {
                         gitHubActions.on.schedule = schedules.schedule;
                     }
+                }
+
+                //workflow_dispatch trigger
+                if (_addWorkflowTrigger)
+                {
+                    gitHubActions.on = new WorkflowDispatchTrigger(gitHubActions.on);
                 }
 
                 //Parameters & Variables

--- a/src/AzurePipelinesToGitHubActionsConverter.Core/Conversion/JobProcessing.cs
+++ b/src/AzurePipelinesToGitHubActionsConverter.Core/Conversion/JobProcessing.cs
@@ -43,7 +43,7 @@ namespace AzurePipelinesToGitHubActionsConverter.Core.Conversion
                 //Initialize the array with no items
                 job.steps = new AzurePipelines.Step[0];
                 //Process the steps, adding the default checkout step
-                newJob.steps = sp.AddSupportingSteps(job.steps, true);
+                newJob.steps = sp.AddSupportingSteps(job.steps);
                 //TODO: There is currently no conversion path for templates
                 newJob.job_message += "Note: Azure DevOps template does not have an equivalent in GitHub Actions yet";
             }
@@ -51,7 +51,7 @@ namespace AzurePipelinesToGitHubActionsConverter.Core.Conversion
             {
                 //Initialize the array with no items
                 job.steps = new AzurePipelines.Step[0];
-                //Process the steps, adding the default checkout step
+                //Process the steps, DO NOT add the default checkout step
                 newJob.steps = sp.AddSupportingSteps(job.strategy?.runOnce?.deploy?.steps, false);
                 //TODO: There is currently no conversion path for templates
                 newJob.job_message += "Note: Azure DevOps strategy>runOnce>deploy does not have an equivalent in GitHub Actions yet";

--- a/src/AzurePipelinesToGitHubActionsConverter.Core/Conversion/PipelineProcessing.cs
+++ b/src/AzurePipelinesToGitHubActionsConverter.Core/Conversion/PipelineProcessing.cs
@@ -1,6 +1,5 @@
 ﻿using AzurePipelinesToGitHubActionsConverter.Core.AzurePipelines;
 using AzurePipelinesToGitHubActionsConverter.Core.GitHubActions;
-using System;
 using System.Collections.Generic;
 
 namespace AzurePipelinesToGitHubActionsConverter.Core.Conversion
@@ -10,10 +9,12 @@ namespace AzurePipelinesToGitHubActionsConverter.Core.Conversion
         public List<string> VariableList;
         public string MatrixVariableName;
         private readonly bool _verbose;
+        private readonly bool _addWorkflowTrigger;
 
-        public PipelineProcessing(bool verbose)
+        public PipelineProcessing(bool verbose, bool? addWorkflowTrigger = null)
         {
             _verbose = verbose;
+            _addWorkflowTrigger = addWorkflowTrigger ?? false;
         }
 
         /// <summary>
@@ -86,6 +87,12 @@ namespace AzurePipelinesToGitHubActionsConverter.Core.Conversion
                     gitHubActions.on = new GitHubActions.Trigger();
                 }
                 gitHubActions.on.schedule = schedules;
+            }
+
+            //workflow_dispatch trigger
+            if (_addWorkflowTrigger)
+            {
+                gitHubActions.on = new WorkflowDispatchTrigger(gitHubActions.on);
             }
 
             //Resources

--- a/src/AzurePipelinesToGitHubActionsConverter.Core/Conversion/Serialization/GitHubActionsSerialization.cs
+++ b/src/AzurePipelinesToGitHubActionsConverter.Core/Conversion/Serialization/GitHubActionsSerialization.cs
@@ -113,7 +113,7 @@ namespace AzurePipelinesToGitHubActionsConverter.Core.Conversion.Serialization
             yaml = yaml.Replace("runs_on", "runs-on");
             yaml = yaml.Replace("_if", "if");
             yaml = yaml.Replace("timeout_minutes", "timeout-minutes");
-            yaml = yaml.Replace("pull_request", "pull-request");
+            // yaml = yaml.Replace("pull_request", "pull-request");
             yaml = yaml.Replace("branches_ignore", "branches-ignore");
             yaml = yaml.Replace("paths_ignore", "paths-ignore");
             yaml = yaml.Replace("tags_ignore", "tags-ignore");

--- a/src/AzurePipelinesToGitHubActionsConverter.Core/Conversion/Serialization/GitHubActionsSerialization.cs
+++ b/src/AzurePipelinesToGitHubActionsConverter.Core/Conversion/Serialization/GitHubActionsSerialization.cs
@@ -99,7 +99,6 @@ namespace AzurePipelinesToGitHubActionsConverter.Core.Conversion.Serialization
             yaml = yaml.Replace("max-parallel", "max_parallel");
             yaml = yaml.Replace("ref", "_ref");
             yaml = yaml.Replace("continue-on-error", "continue_on_error");
-            yaml = yaml.Replace("timeout-minutes", "timeout_minutes");
 
             return GenericObjectSerialization.DeserializeYaml<GitHubActionsRoot>(yaml);
         }
@@ -113,14 +112,12 @@ namespace AzurePipelinesToGitHubActionsConverter.Core.Conversion.Serialization
             yaml = yaml.Replace("runs_on", "runs-on");
             yaml = yaml.Replace("_if", "if");
             yaml = yaml.Replace("timeout_minutes", "timeout-minutes");
-            // yaml = yaml.Replace("pull_request", "pull-request");
             yaml = yaml.Replace("branches_ignore", "branches-ignore");
             yaml = yaml.Replace("paths_ignore", "paths-ignore");
             yaml = yaml.Replace("tags_ignore", "tags-ignore");
             yaml = yaml.Replace("max_parallel", "max-parallel");
             yaml = yaml.Replace("_ref", "ref");
             yaml = yaml.Replace("continue_on_error", "continue-on-error");
-            yaml = yaml.Replace("timeout_minutes", "timeout-minutes");
             yaml = yaml.Replace("step_message:", "#");
             yaml = yaml.Replace("job_message:", "#");
             yaml = yaml.Replace("step_message", "#");

--- a/src/AzurePipelinesToGitHubActionsConverter.Core/Conversion/StepsProcessing.cs
+++ b/src/AzurePipelinesToGitHubActionsConverter.Core/Conversion/StepsProcessing.cs
@@ -522,6 +522,11 @@ namespace AzurePipelinesToGitHubActionsConverter.Core.Conversion
                 gitHubStep._if = ConditionsProcessing.TranslateConditions(step.condition);
             }
 
+            if (gitHubStep.run?.Contains("\\\\r") ?? false)
+            {
+                gitHubStep.step_message = "Note: Script step converted with detected possible carriage return (\\\\r)... Please review script for proper line breaks and correct paths";
+            }
+
             return gitHubStep;
         }
 

--- a/src/AzurePipelinesToGitHubActionsConverter.Core/Conversion/StepsProcessing.cs
+++ b/src/AzurePipelinesToGitHubActionsConverter.Core/Conversion/StepsProcessing.cs
@@ -41,6 +41,9 @@ namespace AzurePipelinesToGitHubActionsConverter.Core.Conversion
                     case "AZUREWEBAPP@1":
                         gitHubStep = CreateAzureWebAppDeploymentStep(step);
                         break;
+                    case "BASH@3":
+                        gitHubStep = CreateScriptStep("bash", step);
+                        break;
                     case "BATCHSCRIPT@1":
                     case "CMDLINE@1":
                     case "CMDLINE@2":

--- a/src/AzurePipelinesToGitHubActionsConverter.Core/Conversion/StepsProcessing.cs
+++ b/src/AzurePipelinesToGitHubActionsConverter.Core/Conversion/StepsProcessing.cs
@@ -121,6 +121,7 @@ namespace AzurePipelinesToGitHubActionsConverter.Core.Conversion
                         gitHubStep = CreateXamariniOSStep(step);
                         break;
 
+                    case "6d15af64-176c-496d-b583-fd2ae21d4df4@1": // Checkout step
                     default:
                         gitHubStep = CreateScriptStep("powershell", step);
                         string newYaml = GenericObjectSerialization.SerializeYaml<AzurePipelines.Step>(step);
@@ -467,11 +468,6 @@ namespace AzurePipelinesToGitHubActionsConverter.Core.Conversion
         {
             string targetType = GetStepInput(step, "targetType");
             string arguments = GetStepInput(step, "arguments");
-
-            if (step.task.ToUpper() == "POWERSHELL@1" || step.task.ToUpper() == "POWERSHELL@2")
-            {
-                var i = 0;
-            }
 
             if (targetType?.ToUpper() == "FILEPATH")
             {

--- a/src/AzurePipelinesToGitHubActionsConverter.Core/Conversion/TriggerProcessing.cs
+++ b/src/AzurePipelinesToGitHubActionsConverter.Core/Conversion/TriggerProcessing.cs
@@ -77,7 +77,6 @@ namespace AzurePipelinesToGitHubActionsConverter.Core.Conversion
             {
                 push = push
             };
-
         }
 
         public GitHubActions.Trigger ProcessTriggerV2(string triggerYaml)

--- a/src/AzurePipelinesToGitHubActionsConverter.Core/GitHubActions/Step.cs
+++ b/src/AzurePipelinesToGitHubActionsConverter.Core/GitHubActions/Step.cs
@@ -5,7 +5,6 @@ namespace AzurePipelinesToGitHubActionsConverter.Core.GitHubActions
 {
     public class Step
     {
-
         public string name { get; set; }
         public string uses { get; set; }
 
@@ -21,8 +20,8 @@ namespace AzurePipelinesToGitHubActionsConverter.Core.GitHubActions
                 if (string.IsNullOrEmpty(value) == false)
                 {
                     //Spaces on the beginning or end seem to be a problem for the YAML serialization, so we Trim() here
-                    //  Also, accidental line feeds in scripts (such as a path including a \r) need to be accounted for
-                    // If this script step includes escaped carriage returns (\\r), switch these to "\\\\r" so that we don't accidentally improperly match these as CRs
+                    //  Also, accidental carriage returns in scripts (such as a path including a \r) need to be accounted for
+                    // If this script step includes escaped carriage returns (\\r), switch these to "\\\\r" so that we don't accidentally improperly match these as CRs; we'll fix these up later when we serialize
                     value = value.Replace("\\r", "\\\\r").Trim();
                 }
 
@@ -36,7 +35,6 @@ namespace AzurePipelinesToGitHubActionsConverter.Core.GitHubActions
         public string _if { get; set; } //https://help.github.com/en/articles/workflow-syntax-for-github-actions#jobsjob_idif
         public bool continue_on_error { get; set; }
         public int timeout_minutes { get; set; }
-
 
         //This is used for tracking errors, so we don't want it to convert to YAML
         //[YamlIgnore]

--- a/src/AzurePipelinesToGitHubActionsConverter.Core/GitHubActions/Step.cs
+++ b/src/AzurePipelinesToGitHubActionsConverter.Core/GitHubActions/Step.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using YamlDotNet.Serialization;
 
 namespace AzurePipelinesToGitHubActionsConverter.Core.GitHubActions
@@ -19,11 +18,14 @@ namespace AzurePipelinesToGitHubActionsConverter.Core.GitHubActions
             }
             set
             {
-                //Spaces on the beginning or end seem to be a problem for the YAML serialization
                 if (string.IsNullOrEmpty(value) == false)
                 {
-                    value = value.Trim();
+                    //Spaces on the beginning or end seem to be a problem for the YAML serialization, so we Trim() here
+                    //  Also, accidental line feeds in scripts (such as a path including a \r) need to be accounted for
+                    // If this script step includes escaped carriage returns (\\r), switch these to "\\\\r" so that we don't accidentally improperly match these as CRs
+                    value = value.Replace("\\r", "\\\\r").Trim();
                 }
+
                 _run = value;
             }
         }

--- a/src/AzurePipelinesToGitHubActionsConverter.Core/GitHubActions/WorkflowDispatchTrigger.cs
+++ b/src/AzurePipelinesToGitHubActionsConverter.Core/GitHubActions/WorkflowDispatchTrigger.cs
@@ -1,0 +1,48 @@
+using YamlDotNet.Serialization;
+
+namespace AzurePipelinesToGitHubActionsConverter.Core.GitHubActions
+{
+    public class WorkflowDispatchTrigger : Trigger
+    {
+        //on:
+        //  workflow_dispatch:
+        //  push:
+        //    branches:    
+        //    - Master
+        //    - Develop
+        //    branches-ignore:
+        //    - 'mona/octocat'
+        //    paths:
+        //    - '**.js'
+        //    paths-ignore:
+        //    - 'docs/**'
+        //  pull-request
+        //    branches:    
+        //    - Master
+        //    - Develop
+        //    branches-ignore:
+        //    - 'mona/octocat'
+        //    paths:
+        //    - '**.js'
+        //    paths-ignore:
+        //    - 'docs/**'
+        //    tags:        
+        //    - v1             # Push events to v1 tag
+        //    - v1.*           # Push events to v1.0, v1.1, and v1.9 tags
+        //  schedule:
+        //  - cron:  '*/15 * * * *' # * is a special character in YAML so you have to quote this string
+
+
+        // DefaultValuesHandling.
+
+        [YamlMember(DefaultValuesHandling = DefaultValuesHandling.Preserve)]
+        public object workflow_dispatch { get; set; }
+
+        public WorkflowDispatchTrigger(Trigger trigger)
+        {
+            this.pull_request = trigger.pull_request;
+            this.push = trigger.push;
+            this.schedule = trigger.schedule;
+        }
+    }
+}

--- a/src/AzurePipelinesToGitHubActionsConverter.sln
+++ b/src/AzurePipelinesToGitHubActionsConverter.sln
@@ -14,6 +14,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		..\README.md = ..\README.md
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AzurePipelinesToGitHubActionsConverter.ConsoleApp", "AzurePipelinesToGitHubActionsConverter.ConsoleApp\AzurePipelinesToGitHubActionsConverter.ConsoleApp.csproj", "{1CE02CA8-4A58-4C12-9EED-38F5C44348C5}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -28,6 +30,10 @@ Global
 		{102D54AE-A0FB-4CE8-972E-5B0A4CF61F7A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{102D54AE-A0FB-4CE8-972E-5B0A4CF61F7A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{102D54AE-A0FB-4CE8-972E-5B0A4CF61F7A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1CE02CA8-4A58-4C12-9EED-38F5C44348C5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1CE02CA8-4A58-4C12-9EED-38F5C44348C5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1CE02CA8-4A58-4C12-9EED-38F5C44348C5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1CE02CA8-4A58-4C12-9EED-38F5C44348C5}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Includes:

- Partial fixes for https://github.com/github/lighthouse-engagements/issues/19
- Fixed issue with `PowerShell@2` conversion missing filepath-based scripts
- Added optional support for `workflow_dispatch` trigger
- Added additional logic for propagating checkout step inputs to the GitHub Checkout Action, and removing extra checkout tasks that come thru as tasks
- Fixed issue where `pull_request` trigger was using incorrect `pull-request` label
- Fixed issue with code/paths in scripts being incorrectly read as carriage returns (\r) and breaking the yaml output
- gitignore adds for VSCode and output folder

