### PR TITLE
Repo name fix when YAML is stored in Azure Repos

### DIFF
--- a/src/AzurePipelinesToGitHubActionsConverter.ConsoleApp/Program.cs
+++ b/src/AzurePipelinesToGitHubActionsConverter.ConsoleApp/Program.cs
@@ -190,7 +190,7 @@ namespace AzurePipelinesToGitHubActionsConverter.ConsoleApp
                         repositoryName = yamlPipeline["repository"]["properties"]["fullName"].Value<string>();
 
                     var task1 = adoService.GetPipelineYaml(baseUrl, opts.Account, opts.Project,
-                        opts.PersonalAccessToken, pipelineId, "6.0-preview.1");
+                        opts.PersonalAccessToken, pipelineId, "6.1-preview.1");
 
                     Task.WaitAll(task1);
 

--- a/src/AzurePipelinesToGitHubActionsConverter.ConsoleApp/Program.cs
+++ b/src/AzurePipelinesToGitHubActionsConverter.ConsoleApp/Program.cs
@@ -181,10 +181,16 @@ namespace AzurePipelinesToGitHubActionsConverter.ConsoleApp
                 foreach (var yamlPipeline in yamlPipelines)
                 {
                     var pipelineId = yamlPipeline["id"].Value<long>();
-                    var repositoryName = yamlPipeline["repository"]["properties"]["shortName"].Value<string>();
+                    string repositoryName = string.Empty;
+                    
+                    // If code is in Azure Repos, there will be no shortName property, should we just use fullname always?
+                    if(yamlPipeline["repository"]["properties"]["shortName"] != null)
+                        repositoryName = yamlPipeline["repository"]["properties"]["shortName"].Value<string>();
+                    else
+                        repositoryName = yamlPipeline["repository"]["properties"]["fullName"].Value<string>();
 
                     var task1 = adoService.GetPipelineYaml(baseUrl, opts.Account, opts.Project,
-                        opts.PersonalAccessToken, pipelineId, "6.1-preview.1");
+                        opts.PersonalAccessToken, pipelineId, "6.0-preview.1");
 
                     Task.WaitAll(task1);
 

--- a/src/AzurePipelinesToGitHubActionsConverter.Core/AzurePipelines/Trigger.cs
+++ b/src/AzurePipelinesToGitHubActionsConverter.Core/AzurePipelines/Trigger.cs
@@ -13,6 +13,8 @@ namespace AzurePipelinesToGitHubActionsConverter.Core.AzurePipelines
     //  paths:
     //    include: [ string ] # file paths which must match to trigger a build
     //    exclude: [ string ] # file paths which will not trigger a build
+    //  enabled:
+    //    added to handle the case where a trigger section is in the yaml file, but set to "none"
     public class Trigger
     {
         //Note: There is no batch property in actions
@@ -24,5 +26,7 @@ namespace AzurePipelinesToGitHubActionsConverter.Core.AzurePipelines
         public IncludeExclude branches { get; set; }
         public IncludeExclude tags { get; set; }
         public IncludeExclude paths { get; set; }
+        [DefaultValue(false)]
+        public bool enabled { get; set; } = false;
     }
 }

--- a/src/AzurePipelinesToGitHubActionsConverter.Core/AzurePipelines/Trigger.cs
+++ b/src/AzurePipelinesToGitHubActionsConverter.Core/AzurePipelines/Trigger.cs
@@ -13,8 +13,6 @@ namespace AzurePipelinesToGitHubActionsConverter.Core.AzurePipelines
     //  paths:
     //    include: [ string ] # file paths which must match to trigger a build
     //    exclude: [ string ] # file paths which will not trigger a build
-    //  enabled:
-    //    added to handle the case where a trigger section is in the yaml file, but set to "none"
     public class Trigger
     {
         //Note: There is no batch property in actions
@@ -26,7 +24,5 @@ namespace AzurePipelinesToGitHubActionsConverter.Core.AzurePipelines
         public IncludeExclude branches { get; set; }
         public IncludeExclude tags { get; set; }
         public IncludeExclude paths { get; set; }
-        [DefaultValue(false)]
-        public bool enabled { get; set; } = false;
     }
 }


### PR DESCRIPTION
Adding a fix for when pipeline yaml files are stored in Azure Repos.

Azure Repos will not return a 'shortName' property so we need to use 'fullName'