### PR TITLE
switched to OrderedDictionary to preserve ordering of env var, with, parameter definitions

### DIFF
--- a/src/AzurePipelinesToGitHubActionsConverter.Core/AzurePipelines/AzurePipelinesRoot.cs
+++ b/src/AzurePipelinesToGitHubActionsConverter.Core/AzurePipelines/AzurePipelinesRoot.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+﻿using System.Collections.Specialized;
 
 //#Example Pipeline YAML:
 //trigger:
@@ -29,9 +29,10 @@ namespace AzurePipelinesToGitHubActionsConverter.Core.AzurePipelines
     {
         public string name { get; set; }
 
-        public Dictionary<string, string> parameters { get; set; }
+        public OrderedDictionary parameters { get; set; }
 
         public string container { get; set; }
+        
         public Resources resources { get; set; }
 
         //Trigger is a complicated case, where it can be a simple list, or a more complex trigger object
@@ -43,7 +44,9 @@ namespace AzurePipelinesToGitHubActionsConverter.Core.AzurePipelines
         //public Trigger trigger { get; set; }
 
         public Trigger pr { get; set; }
+
         public Schedule[] schedules { get; set; }
+
         public Pool pool { get; set; }
 
         public Strategy strategy { get; set; }
@@ -53,9 +56,12 @@ namespace AzurePipelinesToGitHubActionsConverter.Core.AzurePipelines
         //public Dictionary<string, string> variables { get; set; }
 
         public Stage[] stages { get; set; }
+
         public Job[] jobs { get; set; }
+
         public Step[] steps { get; set; }
+
         //TODO: There is currently no conversion path for services
-        public Dictionary<string, string> services { get; set; }        
+        public OrderedDictionary services { get; set; }        
     }
 }

--- a/src/AzurePipelinesToGitHubActionsConverter.Core/AzurePipelines/Job.cs
+++ b/src/AzurePipelinesToGitHubActionsConverter.Core/AzurePipelines/Job.cs
@@ -1,7 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
+using System.Collections.Specialized;
 using System.ComponentModel;
-using System.Text;
 
 namespace AzurePipelinesToGitHubActionsConverter.Core.AzurePipelines
 {
@@ -42,7 +41,7 @@ namespace AzurePipelinesToGitHubActionsConverter.Core.AzurePipelines
         public int timeoutInMinutes { get; set; } = 0;
         [DefaultValue(1)]
         public int cancelTimeoutInMinutes { get; set; } = 1;
-        public Dictionary<string, string> variables { get; set; }
+        public OrderedDictionary variables { get; set; }
         public Step[] steps { get; set; }
         //TODO: There is currently no conversion path for services
         public Dictionary<string, string> services { get; set; }
@@ -75,8 +74,6 @@ namespace AzurePipelinesToGitHubActionsConverter.Core.AzurePipelines
         public Environment environment { get; set; }
 
         public string template { get; set; }
-        public Dictionary<string, string> parameters { get; set; }
-
-
+        public OrderedDictionary parameters { get; set; }
     }
 }

--- a/src/AzurePipelinesToGitHubActionsConverter.Core/AzurePipelines/Stage.cs
+++ b/src/AzurePipelinesToGitHubActionsConverter.Core/AzurePipelines/Stage.cs
@@ -1,23 +1,29 @@
-﻿using System.Collections.Generic;
+﻿using System.Collections.Specialized;
+
 namespace AzurePipelinesToGitHubActionsConverter.Core.AzurePipelines
 {
     public class Stage
     {
-        //https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=azure-devops&tabs=schema%2Cparameter-schema#stage
-        //stages:
-        //- stage: string  # name of the stage (A-Z, a-z, 0-9, and underscore)
-        //  displayName: string  # friendly name to display in the UI
-        //  dependsOn: string | [ string ]
-        //  condition: string
-        //  variables: # several syntaxes, see specific section
-        //  jobs: [ job | templateReference]
+        // https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=azure-devops&tabs=schema%2Cparameter-schema#stage
+        // stages:
+        // - stage: string  # name of the stage (A-Z, a-z, 0-9, and underscore)
+        //   displayName: string  # friendly name to display in the UI
+        //   dependsOn: string | [ string ]
+        //   condition: string
+        //   variables: # several syntaxes, see specific section
+        //   jobs: [ job | templateReference]
         public string stage { get; set; }
+
         public string displayName { get; set; } //This variable is not needed in actions
-        //Add dependsOn processing for stages
+
+        // Add dependsOn processing for stages
         public string[] dependsOn { get; set; }
+
         public string condition { get; set; }
-        //Variables is similar to triggers, this can be a simple list, or a more complex variable object
-        public Dictionary<string, string> variables { get; set; }
+
+        // Variables is similar to triggers, this can be a simple list, or a more complex variable object
+        public OrderedDictionary variables { get; set; }
+
         public Job[] jobs { get; set; }
     }
 }

--- a/src/AzurePipelinesToGitHubActionsConverter.Core/AzurePipelines/Step.cs
+++ b/src/AzurePipelinesToGitHubActionsConverter.Core/AzurePipelines/Step.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+﻿using System.Collections.Specialized;
 using System.ComponentModel;
 
 namespace AzurePipelinesToGitHubActionsConverter.Core.AzurePipelines
@@ -95,8 +95,8 @@ namespace AzurePipelinesToGitHubActionsConverter.Core.AzurePipelines
         public string workingDirectory { get; set; }
         public string failOnStderr { get; set; }
         public Target target { get; set; }
-        public Dictionary<string, string> inputs { get; set; }
-        public Dictionary<string, string> env { get; set; }
-        public Dictionary<string, string> parameters { get; set; }
+        public OrderedDictionary inputs { get; set; }
+        public OrderedDictionary env { get; set; }
+        public OrderedDictionary parameters { get; set; }
     }
 }

--- a/src/AzurePipelinesToGitHubActionsConverter.Core/Conversion/GeneralProcessing.cs
+++ b/src/AzurePipelinesToGitHubActionsConverter.Core/Conversion/GeneralProcessing.cs
@@ -32,6 +32,7 @@ namespace AzurePipelinesToGitHubActionsConverter.Core.Conversion
         public string[] ProcessDependsOnV2(string dependsOnYaml)
         {
             string[] dependsOn = null;
+
             if (dependsOnYaml != null)
             {
                 try
@@ -47,13 +48,14 @@ namespace AzurePipelinesToGitHubActionsConverter.Core.Conversion
                 }
             }
 
-            //Build the return results
+            // Build the return results
             return dependsOn;
         }
 
         public AzurePipelines.Environment ProcessEnvironmentV2(string environmentYaml)
         {
             AzurePipelines.Environment environment = null;
+
             if (environmentYaml != null)
             {
                 try
@@ -68,6 +70,7 @@ namespace AzurePipelinesToGitHubActionsConverter.Core.Conversion
                     {
                         //when the environment is just a simple string, e.g.  //environment: environmentName.resourceName
                         string simpleEnvironment = GenericObjectSerialization.DeserializeYaml<string>(environmentYaml);
+
                         environment = new AzurePipelines.Environment
                         {
                             name = simpleEnvironment
@@ -76,28 +79,37 @@ namespace AzurePipelinesToGitHubActionsConverter.Core.Conversion
                     catch (Exception ex2)
                     {
                         JObject json = JSONSerialization.DeserializeStringToObject(environmentYaml);
+
                         if (json["tags"].Type.ToString() == "String")
                         {
                             string name = null;
+
                             if (json["name"] != null)
                             {
                                 name = json["name"].ToString();
                             }
+
                             string resourceName = null;
+
                             if (json["resourceName"] != null)
                             {
                                 name = json["resourceName"].ToString();
                             }
+
                             string resourceId = null;
+
                             if (json["resourceId"] != null)
                             {
                                 name = json["resourceId"].ToString();
                             }
+
                             string resourceType = null;
+
                             if (json["resourceType"] != null)
                             {
                                 name = json["resourceType"].ToString();
                             }
+
                             environment = new AzurePipelines.Environment
                             {
                                 name = name,
@@ -105,6 +117,7 @@ namespace AzurePipelinesToGitHubActionsConverter.Core.Conversion
                                 resourceId = resourceId,
                                 resourceType = resourceType
                             };
+
                             //Move the single string demands to an array
                             environment.tags = new string[1];
                             environment.tags[0] = json["tags"].ToString();
@@ -126,14 +139,14 @@ namespace AzurePipelinesToGitHubActionsConverter.Core.Conversion
             {
                 try
                 {
-                    Resources resources = GenericObjectSerialization.DeserializeYaml<Resources>(resourcesYaml);
-                    return resources;
+                    return GenericObjectSerialization.DeserializeYaml<Resources>(resourcesYaml);
                 }
                 catch (Exception ex)
                 {
                     ConversionUtility.WriteLine($"DeserializeYaml<Resources>(resourcesYaml) swallowed an exception: " + ex.Message, _verbose);
                 }
             }
+
             return null;
         }
 
@@ -143,7 +156,7 @@ namespace AzurePipelinesToGitHubActionsConverter.Core.Conversion
             {
                 try
                 {
-                    //Most often, the pool will be in this structure
+                    // Most often, the pool will be in this structure
                     AzurePipelines.Strategy strategy = GenericObjectSerialization.DeserializeYaml<AzurePipelines.Strategy>(strategyYaml);
                     return strategy;
                 }
@@ -152,14 +165,15 @@ namespace AzurePipelinesToGitHubActionsConverter.Core.Conversion
                     ConversionUtility.WriteLine($"DeserializeYaml<AzurePipelines.Strategy>(strategyYaml) swallowed an exception: " + ex.Message, _verbose);
                 }
             }
+
             return null;
         }
-   
 
-        //process the build pool/agent
+        // process the build pool/agent
         public string ProcessPool(Pool pool)
         {
             string newPool = null;
+
             if (pool != null)
             {
                 if (pool.vmImage != null)
@@ -171,12 +185,14 @@ namespace AzurePipelinesToGitHubActionsConverter.Core.Conversion
                     newPool = pool.name;
                 }
             }
+
             return newPool;
         }
 
         public Pool ProcessPoolV2(string poolYaml)
         {
             Pool pool = null;
+
             if (poolYaml != null)
             {
                 try
@@ -187,6 +203,7 @@ namespace AzurePipelinesToGitHubActionsConverter.Core.Conversion
                 catch (Exception ex)
                 {
                     ConversionUtility.WriteLine($"DeserializeYaml<Pool>(poolYaml) swallowed an exception: " + ex.Message, _verbose);
+
                     //If it's a simple pool string, and has no json in it, assign it to the name
                     if (poolYaml.IndexOf("{") < 0)
                     {
@@ -199,28 +216,36 @@ namespace AzurePipelinesToGitHubActionsConverter.Core.Conversion
                     {
                         //otherwise, demands is probably a string, instead of string[], let's fix it
                         JObject json = JSONSerialization.DeserializeStringToObject(poolYaml);
+
                         if (json["demands"].Type.ToString() == "String")
                         {
                             string name = null;
+
                             if (json["name"] != null)
                             {
                                 name = json["name"].ToString();
                             }
+
                             string vmImage = null;
+
                             if (json["vmImage"] != null)
                             {
                                 vmImage = json["vmImage"].ToString();
                             }
+
                             string demands = null;
+
                             if (json["demands"] != null)
                             {
                                 demands = json["demands"].ToString();
                             }
+
                             pool = new Pool
                             {
                                 name = name,
                                 vmImage = vmImage
                             };
+
                             //Move the single string demands to an array
                             pool.demands = new string[1];
                             pool.demands[0] = demands;
@@ -232,10 +257,11 @@ namespace AzurePipelinesToGitHubActionsConverter.Core.Conversion
                     }
                 }
             }
+
             return pool;
         }
 
-        //process the strategy matrix
+        // process the strategy matrix
         public GitHubActions.Strategy ProcessStrategy(AzurePipelines.Strategy strategy)
         {
             //Azure DevOps
@@ -268,37 +294,45 @@ namespace AzurePipelinesToGitHubActionsConverter.Core.Conversion
                     {
                         processedStrategy = new GitHubActions.Strategy();
                     }
+
                     string[] matrix = new string[strategy.matrix.Count];
                     KeyValuePair<string, Dictionary<string, string>> matrixVariable = strategy.matrix.First();
                     MatrixVariableName = matrixVariable.Value.Keys.First();
                     int i = 0;
+
                     foreach (KeyValuePair<string, Dictionary<string, string>> entry in strategy.matrix)
                     {
                         matrix[i] = strategy.matrix[entry.Key][MatrixVariableName];
                         i++;
                     }
+
                     processedStrategy.matrix = new Dictionary<string, string[]>
                     {
                         { MatrixVariableName, matrix }
                     };
                 }
+
                 if (strategy.parallel != null)
                 {
                     ConversionUtility.WriteLine("This variable is not needed in actions: " + strategy.parallel, _verbose);
                 }
+
                 if (strategy.maxParallel != null)
                 {
                     if (processedStrategy == null)
                     {
                         processedStrategy = new GitHubActions.Strategy();
                     }
+
                     processedStrategy.max_parallel = strategy.maxParallel;
                 }
+
                 if (strategy.runOnce != null)
                 {
-                    //TODO: There is currently no conversion path for other strategies
+                    // TODO: There is currently no conversion path for other strategies
                     ConversionUtility.WriteLine("TODO: " + strategy.runOnce, _verbose);
                 }
+
                 return processedStrategy;
             }
             else
@@ -335,29 +369,33 @@ namespace AzurePipelinesToGitHubActionsConverter.Core.Conversion
 
             if (resources != null && resources.containers != null && resources.containers.Length > 0)
             {
-                GitHubActions.Container container = new GitHubActions.Container
+                var container = new GitHubActions.Container
                 {
-                    //All containers have at least the image name
+                    // All containers have at least the image name
                     image = resources.containers[0].image
                 };
 
-                //Optionally, these next 4 properties could also exist
+                // Optionally, these next 4 properties could also exist
                 if (resources.containers[0].env != null)
                 {
                     container.env = resources.containers[0].env;
                 }
+
                 if (resources.containers[0].ports != null)
                 {
                     container.ports = resources.containers[0].ports;
                 }
+
                 if (resources.containers[0].volumes != null)
                 {
                     container.volumes = resources.containers[0].volumes;
                 }
+
                 if (resources.containers[0].options != null)
                 {
                     container.options = resources.containers[0].options;
                 }
+
                 return container;
             }
             else
@@ -365,7 +403,5 @@ namespace AzurePipelinesToGitHubActionsConverter.Core.Conversion
                 return null;
             }
         }
-    
-
     }
 }

--- a/src/AzurePipelinesToGitHubActionsConverter.Core/Conversion/VariablesProcessing.cs
+++ b/src/AzurePipelinesToGitHubActionsConverter.Core/Conversion/VariablesProcessing.cs
@@ -41,14 +41,12 @@ namespace AzurePipelinesToGitHubActionsConverter.Core.Conversion
             VariableList = new List<string>();
         }
 
-        //process all (simple) variables
+        // process all (simple) variables
         public OrderedDictionary ProcessSimpleVariables(OrderedDictionary variables)
         {
             if (variables != null)
             {
                 // update variables from the $(variableName) format to ${{variableName}} format, by piping them into a list for replacement later.
-                // VariableList.AddRange(variables.Keys);
-
                 foreach (string key in variables.Keys)
                 {
                     VariableList.Add(key);
@@ -58,7 +56,7 @@ namespace AzurePipelinesToGitHubActionsConverter.Core.Conversion
             return variables;
         }
 
-        //process all (complex) variables
+        // process all (complex) variables
         public OrderedDictionary ProcessComplexVariables(AzurePipelines.Variable[] variables)
         {
             var processedVariables = new OrderedDictionary();
@@ -68,14 +66,14 @@ namespace AzurePipelinesToGitHubActionsConverter.Core.Conversion
                 // update variables from the $(variableName) format to ${{variableName}} format, by piping them into a list for replacement later.
                 for (int i = 0; i < variables.Length; i++)
                 {
-                    //name/value pairs
+                    // name/value pairs
                     if (variables[i].name != null && variables[i].value != null)
                     {
                         processedVariables.Add(variables[i].name, variables[i].value);
                         VariableList.Add(variables[i].name);
                     }
 
-                    //groups
+                    // groups
                     if (variables[i].group != null)
                     {
                         if (!processedVariables.Contains(GroupKey))
@@ -88,7 +86,7 @@ namespace AzurePipelinesToGitHubActionsConverter.Core.Conversion
                         }
                     }
 
-                    //template
+                    // template
                     if (variables[i].template != null)
                     {
                         processedVariables.Add("template", variables[i].template);
@@ -108,14 +106,14 @@ namespace AzurePipelinesToGitHubActionsConverter.Core.Conversion
                 // update variables from the $(variableName) format to ${{variableName}} format, by piping them into a list for replacement later.
                 for (int i = 0; i < variables.Count; i++)
                 {
-                    //name/value pairs
+                    // name/value pairs
                     if (variables[i].name != null && variables[i].value != null)
                     {
                         processedVariables.Add(variables[i].name, variables[i].value);
                         VariableList.Add(variables[i].name);
                     }
 
-                    //groups
+                    // groups
                     if (variables[i].group != null)
                     {
                         if (processedVariables.ContainsKey(GroupKey) == false)
@@ -128,7 +126,7 @@ namespace AzurePipelinesToGitHubActionsConverter.Core.Conversion
                         }
                     }
 
-                    //template
+                    // template
                     if (variables[i].template != null)
                     {
                         processedVariables.Add("template", variables[i].template);
@@ -148,7 +146,7 @@ namespace AzurePipelinesToGitHubActionsConverter.Core.Conversion
                 // update variables from the $(variableName) format to ${{variableName}} format, by piping them into a list for replacement later.
                 for (int i = 0; i < parameter.Count; i++)
                 {
-                    //name/value pairs
+                    // name/value pairs
                     if (parameter[i].name != null )
                     {
                         if (parameter[i].@default == null)
@@ -259,13 +257,13 @@ namespace AzurePipelinesToGitHubActionsConverter.Core.Conversion
             return variableList;
         }
 
-        //Search GitHub object for all environment variables
+        // Search GitHub object for all environment variables
         public void ProcessEnvVars(GitHubActionsRoot gitHubActions)
         {
             DictionaryEntry[] rawEnvValues = null;
 
             // We want to 1) Identify env vars at the workflow, stage/job level(s)
-            //  2) Pre-process these var values to see if they refer to other env vars, as the syntax rules are nuanced
+            // 2) Pre-process these var values to see if they refer to other env vars, as the syntax rules are nuanced
             if (gitHubActions.env != null)
             {
                 // grab the initial values here before processing, so we can compare job vs wf level env
@@ -397,7 +395,7 @@ namespace AzurePipelinesToGitHubActionsConverter.Core.Conversion
             {
                 string item = list[i];
 
-                //Remove leading "$(" and trailing ")"
+                // Remove leading "$(" and trailing ")"
                 if (list[i].Length > 3)
                 {
                     list[i] = list[i].Substring(0, item.Length - 1);
@@ -426,7 +424,7 @@ namespace AzurePipelinesToGitHubActionsConverter.Core.Conversion
             {
                 string item = list[i];
 
-                //Remove leading "${{" and trailing "}}"
+                // Remove leading "${{" and trailing "}}"
                 if (list[i].Length > 5)
                 {
                     list[i] = list[i].Substring(0, item.Length - 2);
@@ -446,7 +444,7 @@ namespace AzurePipelinesToGitHubActionsConverter.Core.Conversion
         public MatchCollection FindPipelineVariables(string input, string varNamePattern)
         {
             // match "varNamePattern" in ${}, ${{}}, $(), $[], but NOT $var
-            //  Allowed ADO var chars here: https://docs.microsoft.com/en-us/azure/devops/pipelines/process/variables?view=azure-devops&tabs=yaml%2Cbatch#variable-characters
+            // Allowed ADO var chars here: https://docs.microsoft.com/en-us/azure/devops/pipelines/process/variables?view=azure-devops&tabs=yaml%2Cbatch#variable-characters
             var varPattern = @"\$(?:\{|\{|\(|\[|\{\{)(" + varNamePattern + @")(?:\}\}|\}|\]|\})?(?:\}\}|\]|\)|\}|\})";
 
             return Regex.Matches(input, varPattern, RegexOptions.IgnoreCase);

--- a/src/AzurePipelinesToGitHubActionsConverter.Core/Conversion/VariablesProcessing.cs
+++ b/src/AzurePipelinesToGitHubActionsConverter.Core/Conversion/VariablesProcessing.cs
@@ -3,7 +3,9 @@ using AzurePipelinesToGitHubActionsConverter.Core.Conversion.Serialization;
 using AzurePipelinesToGitHubActionsConverter.Core.Extensions;
 using AzurePipelinesToGitHubActionsConverter.Core.GitHubActions;
 using System;
+using System.Collections;
 using System.Collections.Generic;
+using System.Collections.Specialized;
 using System.Diagnostics;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -40,21 +42,26 @@ namespace AzurePipelinesToGitHubActionsConverter.Core.Conversion
         }
 
         //process all (simple) variables
-        public Dictionary<string, string> ProcessSimpleVariables(Dictionary<string, string> variables)
+        public OrderedDictionary ProcessSimpleVariables(OrderedDictionary variables)
         {
             if (variables != null)
             {
                 // update variables from the $(variableName) format to ${{variableName}} format, by piping them into a list for replacement later.
-                VariableList.AddRange(variables.Keys);
+                // VariableList.AddRange(variables.Keys);
+
+                foreach (string key in variables.Keys)
+                {
+                    VariableList.Add(key);
+                }
             }
 
             return variables;
         }
 
         //process all (complex) variables
-        public Dictionary<string, string> ProcessComplexVariables(AzurePipelines.Variable[] variables)
+        public OrderedDictionary ProcessComplexVariables(AzurePipelines.Variable[] variables)
         {
-            Dictionary<string, string> processedVariables = new Dictionary<string, string>();
+            var processedVariables = new OrderedDictionary();
 
             if (variables != null)
             {
@@ -71,7 +78,7 @@ namespace AzurePipelinesToGitHubActionsConverter.Core.Conversion
                     //groups
                     if (variables[i].group != null)
                     {
-                        if (!processedVariables.ContainsKey(GroupKey))
+                        if (!processedVariables.Contains(GroupKey))
                         {
                             processedVariables.Add(GroupKey, variables[i].group);
                         }
@@ -158,7 +165,7 @@ namespace AzurePipelinesToGitHubActionsConverter.Core.Conversion
             return processedVariables;
         }
 
-        public Dictionary<string, string> ProcessParametersAndVariablesV2(string parametersYaml, string variablesYaml)
+        public OrderedDictionary ProcessParametersAndVariablesV2(string parametersYaml, string variablesYaml)
         {
             List<Parameter> parameters = null;
 
@@ -166,17 +173,15 @@ namespace AzurePipelinesToGitHubActionsConverter.Core.Conversion
             {
                 try
                 {
-                    Dictionary<string, string> simpleParameters = GenericObjectSerialization.DeserializeYaml<Dictionary<string, string>>(parametersYaml);
+                    OrderedDictionary simpleParameters = GenericObjectSerialization.DeserializeYaml<OrderedDictionary>(parametersYaml);
                     parameters = new List<Parameter>();
 
-                    foreach (KeyValuePair<string, string> item in simpleParameters)
-                    {
-                        parameters.Add(new Parameter
+                    parameters.AddRange(
+                        simpleParameters.Cast<DictionaryEntry>().Select(de => new Parameter
                         {
-                            name = item.Key,
-                            @default = item.Value
-                        });
-                    }
+                            name = de.StringKey(),
+                            @default = de.StringValue()
+                        }));
                 }
                 catch (Exception ex)
                 {
@@ -191,17 +196,15 @@ namespace AzurePipelinesToGitHubActionsConverter.Core.Conversion
             {
                 try
                 {
-                    Dictionary<string, string> simpleVariables = GenericObjectSerialization.DeserializeYaml<Dictionary<string, string>>(variablesYaml);
+                    OrderedDictionary simpleVariables = GenericObjectSerialization.DeserializeYaml<OrderedDictionary>(variablesYaml);
                     variables = new List<Variable>();
 
-                    foreach (KeyValuePair<string, string> item in simpleVariables)
-                    {
-                        variables.Add(new Variable
+                    variables.AddRange(
+                        simpleVariables.Cast<DictionaryEntry>().Select(de => new Variable
                         {
-                            name = item.Key,
-                            value = item.Value
-                        });
-                    }
+                            name = de.StringKey(),
+                            value = de.StringValue()
+                        }));
                 }
                 catch (Exception ex)
                 {
@@ -210,13 +213,13 @@ namespace AzurePipelinesToGitHubActionsConverter.Core.Conversion
                 }
             }
 
-            var env = new Dictionary<string, string>();
+            var env = new OrderedDictionary();
             var processedParameters = ProcessComplexParametersV2(parameters);
             var processedVariables = ProcessComplexVariablesV2(variables);
 
             foreach (KeyValuePair<string, string> item in processedParameters)
             {
-                if (env.ContainsKey(item.Key) == false)
+                if (!env.Contains(item.Key))
                 {
                     env.Add(item.Key, item.Value);
                 }
@@ -224,7 +227,7 @@ namespace AzurePipelinesToGitHubActionsConverter.Core.Conversion
 
             foreach (KeyValuePair<string, string> item in processedVariables)
             {
-                if (env.ContainsKey(item.Key) == false)
+                if (!env.Contains(item.Key))
                 {
                     env.Add(item.Key, item.Value);
                 }
@@ -259,14 +262,15 @@ namespace AzurePipelinesToGitHubActionsConverter.Core.Conversion
         //Search GitHub object for all environment variables
         public void ProcessEnvVars(GitHubActionsRoot gitHubActions)
         {
-            List<KeyValuePair<string, string>> rawEnvValues = null;
+            DictionaryEntry[] rawEnvValues = null;
 
             // We want to 1) Identify env vars at the workflow, stage/job level(s)
             //  2) Pre-process these var values to see if they refer to other env vars, as the syntax rules are nuanced
             if (gitHubActions.env != null)
             {
                 // grab the initial values here before processing, so we can compare job vs wf level env
-                rawEnvValues = gitHubActions.env.ToList();
+                rawEnvValues = new DictionaryEntry[gitHubActions.env.Count];
+                gitHubActions.env.CopyTo(rawEnvValues, 0);
 
                 processVarDict(gitHubActions, gitHubActions.env);
             }
@@ -286,34 +290,38 @@ namespace AzurePipelinesToGitHubActionsConverter.Core.Conversion
             }
         }
 
-        private void processVarDict(GitHubActionsRoot actionsRoot, Dictionary<string, string> envVarTable, List<KeyValuePair<string, string>> parentVarTable = null)
+        private void processVarDict(GitHubActionsRoot actionsRoot, OrderedDictionary envVarTable, DictionaryEntry[] parentVarTable = null)
         {
             if (envVarTable != null)
             {
+                var envVarDict = envVarTable.Cast<DictionaryEntry>().ToList();
+
                 // do we want to filter out env vars that are identical to vars in the parent context? This can easily occur due to templated pipeline conversions
                 if (parentVarTable != null)
                 {
                     // so, for any 'child' level env vars that also exist at the 'parent' level and contain the same value, let's remove them
-                    var sameVars = envVarTable.Where(v => parentVarTable.Any(pv => pv.Key == v.Key)).ToList();
+                    var sameVars = envVarDict.Where(de => parentVarTable.Any(pv => pv.StringKey() == de.StringKey())).ToList();
 
                     foreach (var sameVar in sameVars)
                     {
-                        if (sameVar.Value == parentVarTable.FirstOrDefault(pv => pv.Key ==  sameVar.Key).Value)
+                        if (sameVar.StringValue() == parentVarTable.FirstOrDefault(pv => pv.StringKey() == sameVar.StringKey()).StringValue())
                         {
                             envVarTable.Remove(sameVar.Key);
                         }
                     }
                 }
 
-                // separate groups from vars
-                var groupNames = envVarTable.Where(v => v.Key == GroupKey).Select(g => g.Value).Distinct().ToList();
-                // don't output the group name in our env section
-                envVarTable.Remove(GroupKey);
+                // don't want to output the group name in our env section, so find and remove it
+                int groupIndex = envVarDict.FindIndex(v => v.StringKey() == GroupKey);
 
-                // for any group reference found, see if we've retrieved the group details/vars and convert accordingly
-                foreach (var group in groupNames)
+                if (groupIndex >= 0)
                 {
-                    var varGroup = _variableGroups.SingleOrDefault(g => g.name == group);
+                    // separate group from vars
+                    var groupName = envVarDict[groupIndex].StringValue();
+                    envVarTable.RemoveAt(groupIndex);
+
+                    // if any group reference found, see if we've retrieved the group details/vars and convert accordingly
+                    var varGroup = _variableGroups.SingleOrDefault(g => g.name == groupName);
 
                     foreach (var groupVar in varGroup.variables)
                     {
@@ -321,7 +329,7 @@ namespace AzurePipelinesToGitHubActionsConverter.Core.Conversion
                         if (!groupVar.Value.isSecret) // not secret
                         {
                             // for non-secret values, we'll convert them over directly to env vars
-                            envVarTable.Add(groupVar.Key, groupVar.Value.value);
+                            envVarTable.Insert(groupIndex, groupVar.Key, groupVar.Value.value);
                         }
                         else // secret
                         {
@@ -329,15 +337,17 @@ namespace AzurePipelinesToGitHubActionsConverter.Core.Conversion
                             secrets.Add(groupVar.Key);
 
                             // for secret values, we'll convert them to env vars using the secrets syntax
-                            envVarTable.Add(groupVar.Key, $"${{{{ secrets.{groupVar.Key} }}}}");
+                            envVarTable.Insert(groupIndex, groupVar.Key, $"${{{{ secrets.{groupVar.Key} }}}}");
                         }
+
+                        groupIndex++;
                     }
 
-                    actionsRoot.messages.Add($"Note: The consumed values from a variable group ({group}) has been imported from Azure DevOps. Please review varable usage and any secret values used in this workflow, which have been migrated to GitHub secrets syntax");
+                    actionsRoot.messages.Add($"Note: The consumed values from a variable group ({groupName}) has been imported from Azure DevOps. Please review varable usage and any secret values used in this workflow, which have been migrated to GitHub secrets syntax");
                 }
 
-                // add all non-group vars
-                var envVars = envVarTable.Keys.Distinct().ToList();
+                var envVars = new string[envVarTable.Count];
+                envVarTable.Keys.CopyTo(envVars, 0);
 
                 // add all non-group vars found to our list - these will be the env vars used in other parts of the workflow
                 VariableList.AddRange(envVars);
@@ -345,7 +355,7 @@ namespace AzurePipelinesToGitHubActionsConverter.Core.Conversion
                 // Now, process the values of these env vars - nuanced rules in place for how we refer to var in objects 'above' vs siblings
                 foreach (var key in envVars)
                 {
-                    var varValue = envVarTable[key];
+                    var varValue = envVarTable[key].ToString();
                     var varsUsed = FindPipelineVariables(varValue);
 
                     if (varsUsed.Count > 0)

--- a/src/AzurePipelinesToGitHubActionsConverter.Core/Extensions/Helpers.cs
+++ b/src/AzurePipelinesToGitHubActionsConverter.Core/Extensions/Helpers.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Text.RegularExpressions;
 
 namespace AzurePipelinesToGitHubActionsConverter.Core.Extensions
@@ -13,6 +14,16 @@ namespace AzurePipelinesToGitHubActionsConverter.Core.Extensions
         public static string ReplaceAnyCase(this string value, string pattern, string replacement)
         {
             return Regex.Replace(value, Regex.Escape(pattern), replacement.Replace("$", "$$"), RegexOptions.IgnoreCase);
+        }
+
+        public static string StringKey(this DictionaryEntry de)
+        {
+            return de.Key as string;
+        }
+
+        public static string StringValue(this DictionaryEntry de)
+        {
+            return de.Value as string;
         }
     }
 }

--- a/src/AzurePipelinesToGitHubActionsConverter.Core/GitHubActions/GitHubActionsRoot.cs
+++ b/src/AzurePipelinesToGitHubActionsConverter.Core/GitHubActions/GitHubActionsRoot.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Collections.Specialized;
 using YamlDotNet.Serialization;
 
 namespace AzurePipelinesToGitHubActionsConverter.Core.GitHubActions
@@ -7,10 +8,10 @@ namespace AzurePipelinesToGitHubActionsConverter.Core.GitHubActions
     {
         public string name { get; set; }
         public Trigger on { get; set; }
-        public Dictionary<string, string> env { get; set; }
+        public OrderedDictionary env { get; set; }
         public Dictionary<string, Job> jobs { get; set; }
 
-        //This is used for tracking errors, so we don't want it to convert to YAML
+        // This is used for tracking errors, so we don't want it to convert to YAML
         [YamlIgnore]
         public List<string> messages;
 

--- a/src/AzurePipelinesToGitHubActionsConverter.Core/GitHubActions/Job.cs
+++ b/src/AzurePipelinesToGitHubActionsConverter.Core/GitHubActions/Job.cs
@@ -1,24 +1,32 @@
-﻿using System.Collections.Generic;
+﻿using System.Collections.Specialized;
 
 namespace AzurePipelinesToGitHubActionsConverter.Core.GitHubActions
 {
     public class Job
     {
         public string name { get; set; } //https://help.github.com/en/articles/workflow-syntax-for-github-actions#jobsjob_idname
+
         public string runs_on { get; set; } //https://help.github.com/en/articles/workflow-syntax-for-github-actions#jobsjob_idruns-on
+
         public Strategy strategy { get; set; } //https://help.github.com/en/articles/workflow-syntax-for-github-actions#jobsjob_idstrategy
-        //public T container { get; set; }
+
         public Container container { get; set; } //https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=azure-devops&tabs=schema#job
+
         //public string container { get; set; } //https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=azure-devops&tabs=schema#job
+
         public int timeout_minutes { get; set; } //https://help.github.com/en/articles/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes
+
         public string[] needs { get; set; } //https://help.github.com/en/articles/workflow-syntax-for-github-actions#jobsjob_idneeds
-        public Dictionary<string, string> env { get; set; } //https://help.github.com/en/articles/workflow-syntax-for-github-actions#jobsjob_idenv
+
+        public OrderedDictionary env { get; set; } //https://help.github.com/en/articles/workflow-syntax-for-github-actions#jobsjob_idenv
+
         //as "if" is a reserved word in C#, added an "_", and remove this "_" when serializing
         public string _if { get; set; } //https://help.github.com/en/articles/workflow-syntax-for-github-actions#jobsjob_idif
+
         public bool continue_on_error { get; set; }
+
         public Step[] steps { get; set; } //https://help.github.com/en/articles/workflow-syntax-for-github-actions#jobsjob_idsteps
-        //This is used for tracking errors, so we don't want it to convert to YAML
-        //[YamlIgnore]
+
         public string job_message;
     }
 }

--- a/src/AzurePipelinesToGitHubActionsConverter.Core/GitHubActions/Step.cs
+++ b/src/AzurePipelinesToGitHubActionsConverter.Core/GitHubActions/Step.cs
@@ -1,14 +1,15 @@
-﻿using System.Collections.Generic;
-using YamlDotNet.Serialization;
+﻿using System.Collections.Specialized;
 
 namespace AzurePipelinesToGitHubActionsConverter.Core.GitHubActions
 {
     public class Step
     {
         public string name { get; set; }
+
         public string uses { get; set; }
 
         private string _run = null;
+
         public string run
         {
             get
@@ -20,7 +21,7 @@ namespace AzurePipelinesToGitHubActionsConverter.Core.GitHubActions
                 if (string.IsNullOrEmpty(value) == false)
                 {
                     // Spaces on the beginning or end seem to be a problem for the YAML serialization, so we Trim() here
-                    //  Also, accidental carriage returns in scripts (such as a path including a \r) need to be accounted for
+                    // Also, accidental carriage returns in scripts (such as a path including a \r) need to be accounted for
                     // If this script step includes escaped carriage returns (\\r), switch these to "\\\\r" so that we don't accidentally improperly match these as CRs; we'll fix these up later when we serialize
                     value = value.Replace("\\r", "\\\\r").Trim();
                 }
@@ -28,16 +29,20 @@ namespace AzurePipelinesToGitHubActionsConverter.Core.GitHubActions
                 _run = value;
             }
         }
+
         public string shell { get; set; }
-        public Dictionary<string, string> with { get; set; } //A key value pair similar to env
-        public Dictionary<string, string> env { get; set; } //Similar to the job env: https://help.github.com/en/articles/workflow-syntax-for-github-actions#jobsjob_idenv
-        //as "if" is a reserved word in C#, added an "_", and remove this "_" when serializing
-        public string _if { get; set; } //https://help.github.com/en/articles/workflow-syntax-for-github-actions#jobsjob_idif
+
+        public OrderedDictionary with { get; set; } // A key value pair similar to env
+
+        public OrderedDictionary env { get; set; } // Similar to the job env: https://help.github.com/en/articles/workflow-syntax-for-github-actions#jobsjob_idenv
+
+        // as "if" is a reserved word in C#, added an "_", and remove this "_" when serializing
+        public string _if { get; set; } // https://help.github.com/en/articles/workflow-syntax-for-github-actions#jobsjob_idif
+
         public bool continue_on_error { get; set; }
+
         public int timeout_minutes { get; set; }
 
-        //This is used for tracking errors, so we don't want it to convert to YAML
-        //[YamlIgnore]
         public string step_message;
     }
 }


### PR DESCRIPTION
In working with variable groups, and other things that affect what ends up in the `env` map for a workflow, the existing `Dictionary<string, string>` usage was increasingly problematic due to lack of reliable ordering. This PR switches all relevant `Dictionary<string, string>` usage on our models to `OrderedDictionary`, which preserves the order of elements, even while we manipulate the dictionaries. This results in better output, with group vars being pulled in where expected, and just a general better mapping between ADO var definitions and GitHub Actions `env`. This will also affect `with`, `inputs`, and `parameters`.

Also updated a lot of preexisting comments to use `// comment` styling vs `//comment`.